### PR TITLE
numeric pickers are showing min —> max -1

### DIFF
--- a/ResearchSuiteUI/ResearchSuiteUI/iOS/Views/RSDPickerViewProtocol.swift
+++ b/ResearchSuiteUI/ResearchSuiteUI/iOS/Views/RSDPickerViewProtocol.swift
@@ -268,7 +268,8 @@ open class RSDNumberPickerView : UIPickerView, RSDPickerViewProtocol, UIPickerVi
     
     open func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
         let numSteps = range / interval
-        return Int(round((numSteps as NSNumber).doubleValue)) + 1
+        let numValueRows = numSteps + 1 // n steps means n + 1 values
+        return Int(round((numValueRows as NSNumber).doubleValue)) + 1 // add a row for "no choice selected" at row 0
     }
     
     // MARK: UIPickerViewDelegate


### PR DESCRIPTION
because the empty row 0 of the picker (for “no selection”) was not being accounted for