### PR TITLE
Refactor the form and instruction step view controller to register table cells.

### DIFF
--- a/ResearchSuite/ResearchSuite/RSDChoicePickerTableItemGroup.swift
+++ b/ResearchSuite/ResearchSuite/RSDChoicePickerTableItemGroup.swift
@@ -160,7 +160,7 @@ final class RSDBooleanTableItemGroup : RSDChoicePickerTableItemGroup {
         super.init(beginningRowIndex: beginningRowIndex, inputField: inputField, uiHint: uiHint, choicePicker: choicePicker, answerType: answerType)
     }
     
-    /// Does this input field use a single checkbox or radio button to mark as `true` (ie. selected)?
+    /// Does this input field use a single checkbox or radio button to mark as `true` (i.e. selected)?
     private let singleCheckbox: Bool
     
     /// Override setting the answer to set to `false` rather than `nil` if this is a single selection

--- a/ResearchSuite/ResearchSuite/RSDFormDataType.swift
+++ b/ResearchSuite/ResearchSuite/RSDFormDataType.swift
@@ -188,15 +188,10 @@ public enum RSDFormDataType {
     /// The set of ui hints that can display using a list format such as a scrolling list.
     public var listSelectionHints : Set<RSDFormUIHint> {
         switch self {
-        case .collection(let collectionType, _):
-            if collectionType == .multipleComponent {
-                return []
-            } else {
-                return [.checkbox, .list, .radioButton]
-            }
-            
-        case .base(.boolean):
-            return [.list]
+        case .collection(.singleChoice, _),
+             .collection(.multipleChoice, _),
+             .base(.boolean):
+            return [.list, .checkbox, .radioButton]
             
         default:
             return []

--- a/ResearchSuite/ResearchSuite/RSDTableItem.swift
+++ b/ResearchSuite/ResearchSuite/RSDTableItem.swift
@@ -39,10 +39,38 @@ open class RSDTableItem {
     /// The index of this item relative to all rows in the section in which this item resides.
     public let rowIndex: Int
     
+    /// The string to use as the reuse identifier.
+    public let reuseIdentifier: String
+    
     /// Initialize a new RSDTableItem.
     /// - parameter rowIndex: The index of this item relative to all rows in the section in which this item resides.
-    public init(rowIndex: Int) {
+    public init(rowIndex: Int, reuseIdentifier: String) {
         self.rowIndex = rowIndex
+        self.reuseIdentifier = reuseIdentifier
+    }
+    
+    /// The `RSDTableReuseIdentifier` is a list of reuse identifiers used by this framework
+    /// to register table cells in a table.
+    ///
+    /// In addition to the values listed here, the default behavior for the `RSDTableItem`
+    /// subclasses includes optional support for all standard `RSDFormUIHint` values.
+    ///
+    public enum ReuseIdentifier : String, Codable {
+        
+        /// Display a label (text that cannot be edited). This is used for
+        /// text in a footnote or other additional detail information.
+        case label = "label"
+        
+        /// Display an image.
+        case image = "image"
+    }
+    
+    /// A list of all the `RSDTableItem.reuseIdentifier` values that are standard to this framework.
+    public static var allStandardReuseIdentifiers: [String] {
+        let baseIds: [ReuseIdentifier] = [.label, .image]
+        var reuseIds = baseIds.map { $0.stringValue }
+        reuseIds.append(contentsOf: RSDFormUIHint.allStandardHints.map { $0.stringValue })
+        return reuseIds
     }
 }
 
@@ -58,7 +86,7 @@ public final class RSDTextTableItem : RSDTableItem {
     ///     - text:          The text to display.
     public init(rowIndex: Int, text: String) {
         self.text = text
-        super.init(rowIndex: rowIndex)
+        super.init(rowIndex: rowIndex, reuseIdentifier: RSDTableItem.ReuseIdentifier.label.rawValue)
     }
 }
 
@@ -74,7 +102,7 @@ public final class RSDImageTableItem : RSDTableItem {
     ///     - imageTheme:    The image to display.
     public init(rowIndex: Int, imageTheme: RSDImageThemeElement) {
         self.imageTheme = imageTheme
-        super.init(rowIndex: rowIndex)
+        super.init(rowIndex: rowIndex, reuseIdentifier: RSDTableItem.ReuseIdentifier.image.rawValue)
     }
 }
 
@@ -98,9 +126,13 @@ open class RSDInputFieldTableItem : RSDTableItem {
     ///     - rowIndex:      The index of this item relative to all rows in the section in which this item resides.
     ///     - inputField:    The RSDInputField representing this tableItem.
     ///     - uiHint: The UI hint for this row of the table.
-    public init(rowIndex: Int, inputField: RSDInputField, uiHint: RSDFormUIHint) {
+    public init(rowIndex: Int, inputField: RSDInputField, uiHint: RSDFormUIHint, reuseIdentifier: String? = nil) {
         self.inputField = inputField
         self.uiHint = uiHint
-        super.init(rowIndex: rowIndex)
+        
+        // If the reuse identifier isn't passed to the initializer then set it from the ui hint.
+        let reuseId: String = reuseIdentifier ?? uiHint.stringValue
+        
+        super.init(rowIndex: rowIndex, reuseIdentifier: reuseId)
     }
 }

--- a/ResearchSuite/ResearchSuite/RSDTableItem.swift
+++ b/ResearchSuite/ResearchSuite/RSDTableItem.swift
@@ -49,7 +49,7 @@ open class RSDTableItem {
         self.reuseIdentifier = reuseIdentifier
     }
     
-    /// The `RSDTableReuseIdentifier` is a list of reuse identifiers used by this framework
+    /// The `ReuseIdentifier` is a list of reuse identifiers used by this framework
     /// to register table cells in a table.
     ///
     /// In addition to the values listed here, the default behavior for the `RSDTableItem`

--- a/ResearchSuiteUI/ResearchSuiteUI.xcodeproj/project.pbxproj
+++ b/ResearchSuiteUI/ResearchSuiteUI.xcodeproj/project.pbxproj
@@ -38,7 +38,7 @@
 		FFF2D9891FCF451C007258F8 /* RSDTaskInfoStepViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FF4A2D391F96A6ED00484338 /* RSDTaskInfoStepViewController.xib */; };
 		FFF2D98A1FCF4527007258F8 /* RSDCountdownStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDD780F1FAE96C70024BDD1 /* RSDCountdownStepViewController.swift */; };
 		FFF2D98B1FCF4527007258F8 /* RSDActiveStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDD781E1FAE990F0024BDD1 /* RSDActiveStepViewController.swift */; };
-		FFF2D98C1FCF4527007258F8 /* RSDGenericStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF39E5231F972F5200C366FC /* RSDGenericStepViewController.swift */; };
+		FFF2D98C1FCF4527007258F8 /* RSDTableStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF39E5231F972F5200C366FC /* RSDTableStepViewController.swift */; };
 		FFF2D98D1FCF4527007258F8 /* DebugStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A2D321F9679EC00484338 /* DebugStepViewController.swift */; };
 		FFF2D98E1FCF4527007258F8 /* RSDTaskInfoStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A2D381F96A6ED00484338 /* RSDTaskInfoStepViewController.swift */; };
 		FFF2D98F1FCF4530007258F8 /* RSDCrosshatchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDD77F51FAD24E90024BDD1 /* RSDCrosshatchView.swift */; };
@@ -84,7 +84,7 @@
 		FF25E8361F96ABEB00BC09A8 /* RSDRoundedButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDRoundedButton.swift; sourceTree = "<group>"; };
 		FF25E83A1F96AEAC00BC09A8 /* UIColor+BridgeKeyNames.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+BridgeKeyNames.swift"; sourceTree = "<group>"; };
 		FF25E83F1F96B5B200BC09A8 /* UIFont+BridgeKeyNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+BridgeKeyNames.swift"; sourceTree = "<group>"; };
-		FF39E5231F972F5200C366FC /* RSDGenericStepViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDGenericStepViewController.swift; sourceTree = "<group>"; };
+		FF39E5231F972F5200C366FC /* RSDTableStepViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDTableStepViewController.swift; sourceTree = "<group>"; };
 		FF39E5241F972F7D00C366FC /* RSDStepChoiceCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDStepChoiceCell.swift; sourceTree = "<group>"; };
 		FF39E5261F972F9800C366FC /* RSDStepNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDStepNavigationView.swift; sourceTree = "<group>"; };
 		FF39E5271F972FA500C366FC /* RSDStepProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDStepProgressView.swift; sourceTree = "<group>"; };
@@ -277,7 +277,7 @@
 				FFDD782D1FAE9E220024BDD1 /* Default NIbs */,
 				FFDD780F1FAE96C70024BDD1 /* RSDCountdownStepViewController.swift */,
 				FFDD781E1FAE990F0024BDD1 /* RSDActiveStepViewController.swift */,
-				FF39E5231F972F5200C366FC /* RSDGenericStepViewController.swift */,
+				FF39E5231F972F5200C366FC /* RSDTableStepViewController.swift */,
 				FF478D911FD752E800493A49 /* RSDNavigationController.swift */,
 				FF4A2D381F96A6ED00484338 /* RSDTaskInfoStepViewController.swift */,
 				FF4A2D321F9679EC00484338 /* DebugStepViewController.swift */,
@@ -488,7 +488,7 @@
 				F82F66251FEA4BB600A2258A /* RSDLoadingView.swift in Sources */,
 				FFF2D9A21FCF4FC6007258F8 /* UIFont+BridgeKeyNames.swift in Sources */,
 				F81565C31FF58E78006DA208 /* RSDPickerViewProtocol.swift in Sources */,
-				FFF2D98C1FCF4527007258F8 /* RSDGenericStepViewController.swift in Sources */,
+				FFF2D98C1FCF4527007258F8 /* RSDTableStepViewController.swift in Sources */,
 				FFF2D9981FCF4538007258F8 /* UIImage+Utilities.swift in Sources */,
 				FFF2D9991FCF4538007258F8 /* UIView+Layout.swift in Sources */,
 				FFF2D9941FCF4530007258F8 /* RSDStepNavigationView.swift in Sources */,

--- a/ResearchSuiteUI/ResearchSuiteUI.xcodeproj/project.pbxproj
+++ b/ResearchSuiteUI/ResearchSuiteUI.xcodeproj/project.pbxproj
@@ -277,8 +277,8 @@
 				FFDD782D1FAE9E220024BDD1 /* Default NIbs */,
 				FFDD780F1FAE96C70024BDD1 /* RSDCountdownStepViewController.swift */,
 				FFDD781E1FAE990F0024BDD1 /* RSDActiveStepViewController.swift */,
-				FF39E5231F972F5200C366FC /* RSDTableStepViewController.swift */,
 				FF478D911FD752E800493A49 /* RSDNavigationController.swift */,
+				FF39E5231F972F5200C366FC /* RSDTableStepViewController.swift */,
 				FF4A2D381F96A6ED00484338 /* RSDTaskInfoStepViewController.swift */,
 				FF4A2D321F9679EC00484338 /* DebugStepViewController.swift */,
 			);

--- a/ResearchSuiteUI/ResearchSuiteUI/iOS/RSDTaskViewController.swift
+++ b/ResearchSuiteUI/ResearchSuiteUI/iOS/RSDTaskViewController.swift
@@ -229,7 +229,7 @@ open class RSDTaskViewController: UIViewController, RSDTaskController, UIPageVie
     /// 2. If `step.stepType == .countdown` then instantiate a `RSDCountdownStepViewController`.
     /// 3. If the step implements the `RSDActiveUIStep` protocol, `duration > 0`, and the step includes the command for
     ///    `RSDActiveUIStepCommand.transitionAutomatically` then instantiate a `RSDActiveStepViewController`.
-    /// 4. If `RSDGenericStepViewController.doesSupport()` returns `true` then instantiate a `RSDGenericStepViewController`
+    /// 4. If `RSDTableStepViewController.doesSupport()` returns `true` then instantiate a `RSDTableStepViewController`
     /// 5. Otherwise, instantiate a `DebugStepViewController` to be used during development as a placeholder.
     ///
     /// - parameter step: The step to display.
@@ -248,10 +248,10 @@ open class RSDTaskViewController: UIViewController, RSDTaskController, UIPageVie
             activeStep.commands.contains(.transitionAutomatically) {
             return RSDActiveStepViewController(step: step)
         }
-        else if RSDGenericStepViewController.doesSupport(step) {
+        else if RSDTableStepViewController.doesSupport(step) {
             // If this step *can* be displayed using the generic step view controller, then default to that
             // rather than the using the debug step.
-            return RSDGenericStepViewController(step: step)
+            return RSDTableStepViewController(step: step)
         }
         else {
             // If no default is set the use the debug controller

--- a/ResearchSuiteUI/ResearchSuiteUI/iOS/Step View Controllers/RSDTableStepViewController.swift
+++ b/ResearchSuiteUI/ResearchSuiteUI/iOS/Step View Controllers/RSDTableStepViewController.swift
@@ -427,39 +427,52 @@ open class RSDTableStepViewController: RSDStepViewController, UITableViewDataSou
         return tableData?.sections[section].rowCount() ?? 0
     }
     
-    /// Instantiate or dequeue a cell for the given index path. The default implementation will use a unique identifier
-    /// as the reuse identifier. It will then call `dequeueCell(in:, at:)` to dequeue the cell followed by calling
-    /// `configure(cell:, in:, at:)` to configure the cell.
+    /// Instantiate or dequeue a cell for the given index path. The default implementation will call
+    /// `dequeueCell(in:, at:)` to dequeue the cell followed by calling `configure(cell:, in:, at:)`
+    /// to configure the cell.
     ///
     /// - parameters:
     ///     - tableView: The table view.
     ///     - indexPath: The given index path.
     /// - returns: The table view cell configured for this index path.
     open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = dequeueCell(in: tableView, for: indexPath) ?? UITableViewCell(style: .default, reuseIdentifier: "__BasicCell")
+        let cell = dequeueCell(in: tableView, for: indexPath)
         configure(cell: cell, in: tableView, at: indexPath)
         return cell
     }
     
     // UI Implementation
     
-    /// Dequeue a cell that is appropriate for the item at the given index path.
+    /// Dequeue a cell that is appropriate for the item at the given index path. By default,
+    /// this method will call `reuseIdentifier(for:)` followed by `registerReuseIdentifierIfNeeded()`
+    /// to register the table view cell reuse identifier before calling `dequeueReusableCell()`
+    /// on the given table view.
     ///
     /// - parameters:
     ///     - tableView: The table view.
     ///     - indexPath: The given index path.
     /// - returns: The table view cell dequeued for this index path.
-    open func dequeueCell(in tableView: UITableView, for indexPath: IndexPath) -> UITableViewCell? {
-        
-        // If there isn't a table item in the tableData associated with this index path then this is a failure.
-        // Assert and return a placeholder cell.
+    open func dequeueCell(in tableView: UITableView, for indexPath: IndexPath) -> UITableViewCell {
+        let reuseId = reuseIdentifier(for: indexPath)
+        registerReuseIdentifierIfNeeded(reuseId)
+        return tableView.dequeueReusableCell(withIdentifier: reuseId, for: indexPath)
+    }
+    
+    /// Returns the cell reuse identifier for a given index path.
+    ///
+    /// By default, this will look for a `RSDTableItem` at the given index path and return the
+    /// `reuseIdentifier` property on that object. If there isn't a table item in the tableData
+    /// associated with this index path then this is a failure. The default behavior is to throw
+    /// an assertion and return a placeholder cell identifier.
+    ///
+    /// - parameter indexPath: The given index path.
+    /// - returns: The reuse identifier for the given index path.
+    open func reuseIdentifier(for indexPath: IndexPath) -> String {
         guard let tableItem = tableData?.tableItem(at: indexPath) else {
             assertionFailure("Failed to get an RSDTableItem for this index path \(indexPath)")
-            return nil
+            return "__BasicCell"
         }
-        
-        registerReuseIdentifierIfNeeded(tableItem.reuseIdentifier)
-        return tableView.dequeueReusableCell(withIdentifier: tableItem.reuseIdentifier, for: indexPath)
+        return tableItem.reuseIdentifier
     }
     
     /// Configure a cell that is appropriate for the item at the given index path.
@@ -471,21 +484,21 @@ open class RSDTableStepViewController: RSDStepViewController, UITableViewDataSou
     open func configure(cell: UITableViewCell, in tableView: UITableView, at indexPath: IndexPath) {
         
         if let labelCell = cell as? RSDTextLabelCell {
-            configure(labelCell: labelCell, for: indexPath)
+            configure(labelCell: labelCell, at: indexPath)
         }
         else if let imageCell = cell as? RSDImageViewCell {
-            configure(imageCell: imageCell, for: indexPath)
+            configure(imageCell: imageCell, at: indexPath)
         }
         else if let textFieldCell = cell as? RSDStepTextFieldCell {
-            configure(textFieldCell: textFieldCell, for: indexPath)
+            configure(textFieldCell: textFieldCell, at: indexPath)
         }
         else if let choiceCell = cell as? RSDStepChoiceCell {
-            configure(choiceCell: choiceCell, for: indexPath)
+            configure(choiceCell: choiceCell, at: indexPath)
         }
     }
     
     /// Configure a label cell.
-    func configure(labelCell: RSDTextLabelCell, for indexPath: IndexPath) {
+    func configure(labelCell: RSDTextLabelCell, at indexPath: IndexPath) {
         guard let item = tableData?.tableItem(at: indexPath) as? RSDTextTableItem
             else {
                 return
@@ -494,7 +507,7 @@ open class RSDTableStepViewController: RSDStepViewController, UITableViewDataSou
     }
     
     /// Configure an image cell.
-    func configure(imageCell: RSDImageViewCell, for indexPath: IndexPath) {
+    func configure(imageCell: RSDImageViewCell, at indexPath: IndexPath) {
         guard let item = tableData?.tableItem(at: indexPath) as? RSDImageTableItem
             else {
                 return
@@ -503,7 +516,7 @@ open class RSDTableStepViewController: RSDStepViewController, UITableViewDataSou
     }
     
     /// Configure a choice cell.
-    func configure(choiceCell: RSDStepChoiceCell, for indexPath: IndexPath) {
+    func configure(choiceCell: RSDStepChoiceCell, at indexPath: IndexPath) {
         guard let tableItem = tableData?.tableItem(at: indexPath) as? RSDChoiceTableItem
             else {
                 return
@@ -513,7 +526,7 @@ open class RSDTableStepViewController: RSDStepViewController, UITableViewDataSou
     }
     
     /// Configure a text field cell.
-    func configure(textFieldCell: RSDStepTextFieldCell, for indexPath: IndexPath) {
+    func configure(textFieldCell: RSDStepTextFieldCell, at indexPath: IndexPath) {
         guard let itemGroup = tableData?.itemGroup(at: indexPath) as? RSDInputFieldTableItemGroup,
             let tableItem = tableData?.tableItem(at: indexPath) as? RSDTextInputTableItem
             else {
@@ -972,4 +985,3 @@ fileprivate struct RSDDefaultGenericStepLayoutConstants {
 
 extension RSDDefaultGenericStepLayoutConstants : RSDTableStepLayoutConstants {
 }
-

--- a/ResearchSuiteUI/ResearchSuiteUI/iOS/Views/RSDStepChoiceCell.swift
+++ b/ResearchSuiteUI/ResearchSuiteUI/iOS/Views/RSDStepChoiceCell.swift
@@ -68,10 +68,8 @@ public class RSDStepChoiceCell: UITableViewCell {
             shadowView.alpha = shadowAlpha
         }
     }
-
-    public init(uiHint: RSDFormUIHint, reuseIdentifier: String?) {
-        // TODO: syoung 12/18/2017 Support checkbox and radio button hint types.
-        // https://github.com/ResearchKit/SageResearch/issues/9
+    
+    public override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: .default, reuseIdentifier: reuseIdentifier)
         commonInit()
     }
@@ -128,7 +126,7 @@ public class RSDStepChoiceCell: UITableViewCell {
 open class RSDStepTextFieldCell: UITableViewCell {
     
     /// The text field associated with this cell.
-    public var textField: UITextField!
+    public var textField: RSDStepTextField!
     
     /// The label used to display the prompt for the input field.
     open var fieldLabel: UILabel!
@@ -171,9 +169,13 @@ open class RSDStepTextFieldCell: UITableViewCell {
     /// Set the string for the text field placeholder. View controllers should use this methods rather
     /// than accessing the text field's 'placeholder' directly because some subclasses may not display
     /// the placeholder text.
-    /// - parameter text:    The 'String' to use as the text field's placeholder text.
-    open func setPlaceholderText(_ text: String) {
-        textField.placeholder = text
+    open var placeholderText: String? {
+        get {
+            return textField.placeholder
+        }
+        set {
+            textField.placeholder = newValue
+        }
     }
     
     public override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
@@ -266,11 +268,6 @@ open class RSDStepTextFieldFeaturedCell: RSDStepTextFieldCell {
         
         // we don't want the field label
         fieldLabel.isHidden = true
-    }
-    
-    /// Override `setPlaceholderText()` to block displaying the placeholder text.
-    override open func setPlaceholderText(_ text: String) {
-        // we don't want placeholder text
     }
 
     override open func updateConstraints() {

--- a/ResearchSuiteUI/ResearchSuiteUI/iOS/Views/RSDStepNavigationView.swift
+++ b/ResearchSuiteUI/ResearchSuiteUI/iOS/Views/RSDStepNavigationView.swift
@@ -181,7 +181,7 @@ extension DefaultNavigationHeaderLayoutConstants : RSDNavigationHeaderLayoutCons
 }
 
 /// `RSDStepHeaderView` is a custom `UIView` designed for use as a header view in a table view, such as
-/// an `RSDGenericStepViewController`.
+/// an `RSDTableStepViewController`.
 @IBDesignable
 open class RSDStepHeaderView: RSDNavigationHeaderView {
     
@@ -219,7 +219,7 @@ open class RSDStepHeaderView: RSDNavigationHeaderView {
     }
 }
 
-/// `RSDGenericStepHeaderView` is a concrete implementation of `RSDStepHeaderView` that will automatically
+/// `RSDTableStepHeaderView` is a concrete implementation of `RSDStepHeaderView` that will automatically
 /// lay out the UI elements in this order, from top to bottom of the view:
 ///
 /// 1. cancelButton: UIButton - allows for cancelling the task
@@ -234,7 +234,7 @@ open class RSDStepHeaderView: RSDNavigationHeaderView {
 /// or progressView, and providing a minimumHeight or customView.
 ///
 @IBDesignable
-open class RSDGenericStepHeaderView: RSDStepHeaderView {
+open class RSDTableStepHeaderView: RSDStepHeaderView {
     
     public init() {
         super.init(frame: CGRect.zero)
@@ -472,7 +472,7 @@ open class RSDGenericStepHeaderView: RSDStepHeaderView {
 }
 
 /// `RSDNavigationFooterView` is an abstract implementation for the `RSDStepNavigationView` which can be
-/// added to a Nib, Storyboard or instantiated using the `RSDGenericStepUIConfig.instantiatNavigationView()`
+/// added to a Nib, Storyboard or instantiated using the `RSDTableStepUIConfig.instantiatNavigationView()`
 /// method.
 @IBDesignable
 open class RSDNavigationFooterView: RSDStepNavigationView {
@@ -487,7 +487,7 @@ open class RSDNavigationFooterView: RSDStepNavigationView {
             return _shouldShowShadow
         }
         set {
-            let shadowEnabled = RSDGenericStepUIConfig.shouldShowNavigationViewShadow()
+            let shadowEnabled = RSDTableStepUIConfig.shouldShowNavigationViewShadow()
             _shouldShowShadow = shadowEnabled && newValue
             self.shadowView?.isHidden = !_shouldShowShadow
             self.clipsToBounds = !_shouldShowShadow


### PR DESCRIPTION
The previous design is based on ORKFormStepViewController and was architected to
dequeue a cell based on the indexPath rather than dequeuing cells using the newer
method that also includes the index path. By using the newer method, the OS will
track selection state and cell size, and this allows both registering table cells
in code and/or using a storyboard or nib to design custom versions of the view
controller.