### PR TITLE
Allow JSON coding override of basic UI elements for specific devices.

### DIFF
--- a/ResearchSuite/ResearchSuite/RSDDeviceType.swift
+++ b/ResearchSuite/ResearchSuite/RSDDeviceType.swift
@@ -99,3 +99,18 @@ extension RSDDeviceType : ExpressibleByStringLiteral {
         self.init(rawValue: value)
     }
 }
+
+extension RSDDeviceType : CodingKey {
+    
+    public init?(stringValue: String) {
+        self.init(rawValue: stringValue)
+    }
+    
+    public var intValue: Int? {
+        return nil
+    }
+    
+    public init?(intValue: Int) {
+        return nil
+    }
+}

--- a/ResearchSuite/ResearchSuite/RSDFactory.swift
+++ b/ResearchSuite/ResearchSuite/RSDFactory.swift
@@ -41,6 +41,20 @@ open class RSDFactory {
     /// then this will be used.
     public static var shared = RSDFactory()
     
+    /// The type of device to point use when decoding different text depending upon the target
+    /// device.
+    public internal(set) var deviceType: RSDDeviceType = {
+        #if os(watchOS)
+        return .watch
+        #elseif os(iOS)
+        return .phone
+        #elseif os(tvOS)
+        return .tv
+        #else
+        return .computer
+        #endif
+    }()
+    
     // Initializer
     public init() {
     }

--- a/ResearchSuite/ResearchSuite/RSDUIStepObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDUIStepObject.swift
@@ -200,6 +200,15 @@ open class RSDUIStepObject : RSDUIActionHandlerObject, RSDThemedUIStep, RSDNavig
         
         self.nextStepIdentifier = try container.decodeIfPresent(String.self, forKey: .nextStepIdentifier)
         
+        try super.init(from: decoder)
+        
+        try decode(from: decoder, for: nil)
+    }
+    
+    func decode(from decoder: Decoder, for deviceType: RSDDeviceType?) throws {
+        
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
         self.title = try container.decodeIfPresent(String.self, forKey: .title)
         self.text = try container.decodeIfPresent(String.self, forKey: .text)
         self.detail = try container.decodeIfPresent(String.self, forKey: .detail)
@@ -218,7 +227,14 @@ open class RSDUIStepObject : RSDUIActionHandlerObject, RSDThemedUIStep, RSDNavig
             }
         }
         
-        try super.init(from: decoder)
+        if deviceType == nil {
+            let subcontainer = try decoder.container(keyedBy: RSDDeviceType.self)
+            let preferredType = decoder.factory.deviceType
+            if subcontainer.contains(preferredType) {
+                let subdecoder = try subcontainer.superDecoder(forKey: preferredType)
+                try decode(from: subdecoder, for: preferredType)
+            }
+        }
     }
     
     /// A step to merge with this step that carries replacement info. This step will look at the replacement info

--- a/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableStepObjectTests.swift
+++ b/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableStepObjectTests.swift
@@ -111,6 +111,45 @@ class CodableStepObjectTests: XCTestCase {
         }
     }
     
+    func testUIStepObject_DeviceType_Codable() {
+        
+        let json = """
+        {
+            "identifier": "foo",
+            "type": "instruction",
+            "title": "Hello World!",
+            "text": "Some text.",
+            "detail": "This is a test.",
+            "footnote": "This is a footnote.",
+            "watch" : {
+                "title": "Watch: Hello World!",
+                "text": "Watch: Some text.",
+                "detail": "Watch: This is a test.",
+                "footnote": "Watch: This is a footnote."
+            }
+        }
+        """.data(using: .utf8)! // our data in native (JSON) format
+        
+        do {
+            
+            let factory = RSDFactory()
+            factory.deviceType = .watch
+            let decoder = factory.createJSONDecoder()
+            
+            let object = try decoder.decode(RSDUIStepObject.self, from: json)
+            
+            XCTAssertEqual(object.identifier, "foo")
+            XCTAssertEqual(object.title, "Watch: Hello World!")
+            XCTAssertEqual(object.text, "Watch: Some text.")
+            XCTAssertEqual(object.detail, "Watch: This is a test.")
+            XCTAssertEqual(object.footnote, "Watch: This is a footnote.")
+            
+        } catch let err {
+            XCTFail("Failed to decode/encode object: \(err)")
+            return
+        }
+    }
+    
     func testUIStepObjectWithThemes_Codable() {
         
         let json = """


### PR DESCRIPTION
When adding the watch UI, one of the issues was that the text strings have to be shorter on a watch than what you want on a phone. Add optional override of default UI elements *if* there is a device key subtype defined.