### PR TITLE
Change “placeholderText” key to “placeholder”

### DIFF
--- a/ResearchSuite/ResearchSuite/RSDHumanMeasurementTableItemGroup.swift
+++ b/ResearchSuite/ResearchSuite/RSDHumanMeasurementTableItemGroup.swift
@@ -69,7 +69,7 @@ open class RSDHumanMeasurementTableItemGroup : RSDInputFieldTableItemGroup {
             // TODO: syoung 12/19/2017 Implement for both text field and picker
             // https://github.com/ResearchKit/SageResearch/issues/6
             answerType = RSDAnswerResultType(baseType: .decimal, sequenceType: .array, formDataType: inputField.dataType, dateFormat: nil, unit: nil, sequenceSeparator: "/")
-            let tableItem = RSDTextInputTableItem(rowIndex: beginningRowIndex, inputField: inputField, uiHint: uiHint, answerType: answerType, textFieldOptions: nil, formatter: nil, pickerSource: nil, placeholderText: nil)
+            let tableItem = RSDTextInputTableItem(rowIndex: beginningRowIndex, inputField: inputField, uiHint: uiHint, answerType: answerType, textFieldOptions: nil, formatter: nil, pickerSource: nil, placeholder: nil)
             tableItems = [tableItem]
         }
         

--- a/ResearchSuite/ResearchSuite/RSDInputField.swift
+++ b/ResearchSuite/ResearchSuite/RSDInputField.swift
@@ -53,7 +53,7 @@ public protocol RSDInputField {
     ///
     /// You can display placeholder text in a text field or text area to help users understand how to answer
     /// the item's question.
-    var placeholderText: String? { get }
+    var placeholder: String? { get }
     
     /// A Boolean value indicating whether the user can skip the input field without providing an answer.
     var isOptional: Bool { get }

--- a/ResearchSuite/ResearchSuite/RSDInputFieldObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDInputFieldObject.swift
@@ -56,7 +56,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
     ///
     /// You can display placeholder text in a text field or text area to help users understand how to answer
     /// the item's question.
-    open var placeholderText: String?
+    open var placeholder: String?
     
     /// Options for displaying a text field. This is only applicable for certain types of UI hints and data types.
     open var textFieldOptions: RSDTextFieldOptions?
@@ -108,7 +108,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
     private enum CodingKeys : String, CodingKey {
         case identifier
         case prompt
-        case placeholderText
+        case placeholder
         case dataType
         case uiHint
         case isOptional = "optional"
@@ -233,7 +233,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
     ///     {
     ///     "identifier": "foo",
     ///     "prompt": "Text",
-    ///     "placeholderText": "enter text",
+    ///     "placeholder": "enter text",
     ///     "dataType": "singleChoice.string",
     ///     "choices" : ["never", "sometimes", "often", "always"],
     ///     "matchingAnswer": "never"
@@ -329,7 +329,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
         self.surveyRules = surveyRules
         self.identifier = try container.decode(String.self, forKey: .identifier)
         self.prompt = try container.decodeIfPresent(String.self, forKey: .prompt)
-        self.placeholderText = try container.decodeIfPresent(String.self, forKey: .placeholderText)
+        self.placeholder = try container.decodeIfPresent(String.self, forKey: .placeholder)
         self.isOptional = try container.decodeIfPresent(Bool.self, forKey: .isOptional) ?? false
     }
     
@@ -341,7 +341,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
         try container.encode(self.identifier, forKey: .identifier)
         try container.encode(self.dataType, forKey: .dataType)
         try container.encodeIfPresent(prompt, forKey: .prompt)
-        try container.encodeIfPresent(placeholderText, forKey: .placeholderText)
+        try container.encodeIfPresent(placeholder, forKey: .placeholder)
         try container.encodeIfPresent(uiHint, forKey: .uiHint)
         if let obj = self.range {
             let nestedEncoder = container.superEncoder(forKey: .range)
@@ -379,7 +379,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
     }
     
     private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.identifier, .prompt, .placeholderText, .dataType, .uiHint, .isOptional, .textFieldOptions, .range, .surveyRules]
+        let codingKeys: [CodingKeys] = [.identifier, .prompt, .placeholder, .dataType, .uiHint, .isOptional, .textFieldOptions, .range, .surveyRules]
         return codingKeys
     }
     
@@ -391,7 +391,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
                 if idx != 0 { return false }
             case .prompt:
                 if idx != 1 { return false }
-            case .placeholderText:
+            case .placeholder:
                 if idx != 2 { return false }
             case .dataType:
                 if idx != 3 { return false }
@@ -427,7 +427,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
                          "prompt" : "This is a date input field",
                          "dataType" : "date",
                          "uiHint" : "picker",
-                         "placeholderText" : "enter a date",
+                         "placeholder" : "enter a date",
                          "range" : [ "minimumDate" : "2017-02-20",
                                      "maximumDate" : "2017-03-20",
                                      "codingFormat" : "yyyy-MM-dd"]]
@@ -436,7 +436,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
                          "prompt" : "This is a decimal input field",
                          "dataType" : "decimal",
                          "uiHint" : "slider",
-                         "placeholderText" : "select a numer",
+                         "placeholder" : "select a numer",
                          "range" : [ "minimumValue" : -2.5,
                                      "maximumValue" : 3,
                                      "stepInterval" : 0.1,
@@ -453,7 +453,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
                          "prompt" : "This is a integer input field",
                          "dataType" : "integer",
                          "uiHint" : "popover",
-                         "placeholderText" : "select a numer",
+                         "placeholder" : "select a numer",
                          "range" : [ "minimumValue" : -10,
                                      "maximumValue" : 10,
                                      "stepInterval" : 2],
@@ -464,14 +464,14 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
                          "prompt" : "This is a year input field",
                          "dataType" : "year",
                          "uiHint" : "textfield",
-                         "placeholderText" : "birth year",
+                         "placeholder" : "birth year",
                          "range" : [ "allowFuture" : false]]
             
             case .string:
                 return [ "identifier" : "stringExample",
                          "prompt" : "This is a string input field",
                          "dataType" : "string",
-                         "placeholderText" : "enter some text",
+                         "placeholder" : "enter some text",
                          "textFieldOptions" : [ "keyboardType" : "asciiCapable"]]
             }
         }

--- a/ResearchSuite/ResearchSuite/RSDMeasurementInputTableItem.swift
+++ b/ResearchSuite/ResearchSuite/RSDMeasurementInputTableItem.swift
@@ -60,7 +60,7 @@ final class RSDHeightInputTableItem : RSDTextInputTableItem {
         
         // Setup the formatter.
         var formatter: Formatter? = (inputField.range as? RSDRangeWithFormatter)?.formatter
-        var placeholderText: String?
+        var placeholder: String?
         if (formatter == nil) {
             let lengthFormatter = RSDLengthFormatter(forChildUse: (measurementSize != .adult), unitSymbol: unit)
             formatter = lengthFormatter
@@ -72,9 +72,9 @@ final class RSDHeightInputTableItem : RSDTextInputTableItem {
             // locale is used to determine the preferred units.
             lengthFormatter.unitStyle = .long
             if Locale.current.usesMetricSystem {
-                placeholderText = lengthFormatter.unitString(fromValue: 250, unit: .centimeter)
+                placeholder = lengthFormatter.unitString(fromValue: 250, unit: .centimeter)
             } else {
-                placeholderText = lengthFormatter.unitString(fromValue: 60, unit: .inch)
+                placeholder = lengthFormatter.unitString(fromValue: 60, unit: .inch)
             }
             lengthFormatter.unitStyle = .short
             
@@ -102,7 +102,7 @@ final class RSDHeightInputTableItem : RSDTextInputTableItem {
         
         let answerType = RSDAnswerResultType(baseType: .decimal, sequenceType: nil, formDataType: inputField.dataType, dateFormat: nil, unit: unit, sequenceSeparator: nil)
         
-        super.init(rowIndex: rowIndex, inputField: inputField, uiHint: hint, answerType: answerType, textFieldOptions: nil, formatter: formatter, pickerSource: pickerSource, placeholderText: placeholderText)
+        super.init(rowIndex: rowIndex, inputField: inputField, uiHint: hint, answerType: answerType, textFieldOptions: nil, formatter: formatter, pickerSource: pickerSource, placeholder: placeholder)
     }
     
     /// Override the `convertAnswer()` function to convert the `Measurement` returned
@@ -140,7 +140,7 @@ final class RSDMassInputTableItem : RSDTextInputTableItem {
         
         // Setup the formatter.
         var formatter: Formatter? = (inputField.range as? RSDRangeWithFormatter)?.formatter
-        var placeholderText: String?
+        var placeholder: String?
         if (formatter == nil) {
             let massFormatter = RSDMassFormatter(forInfantUse: (measurementSize == .infant), unitSymbol: unit)
             formatter = massFormatter
@@ -152,9 +152,9 @@ final class RSDMassInputTableItem : RSDTextInputTableItem {
             // locale is used to determine the preferred units.
             massFormatter.unitStyle = .long
             if Locale.current.usesMetricSystem {
-                placeholderText = massFormatter.unitString(fromValue: 60, unit: .kilogram)
+                placeholder = massFormatter.unitString(fromValue: 60, unit: .kilogram)
             } else {
-                placeholderText = massFormatter.unitString(fromValue: 140, unit: .pound)
+                placeholder = massFormatter.unitString(fromValue: 140, unit: .pound)
             }
             massFormatter.unitStyle = .medium
             
@@ -182,7 +182,7 @@ final class RSDMassInputTableItem : RSDTextInputTableItem {
         
         let answerType = RSDAnswerResultType(baseType: .decimal, sequenceType: nil, formDataType: inputField.dataType, dateFormat: nil, unit: unit, sequenceSeparator: nil)
         
-        super.init(rowIndex: rowIndex, inputField: inputField, uiHint: hint, answerType: answerType, textFieldOptions: nil, formatter: formatter, pickerSource: pickerSource, placeholderText: placeholderText)
+        super.init(rowIndex: rowIndex, inputField: inputField, uiHint: hint, answerType: answerType, textFieldOptions: nil, formatter: formatter, pickerSource: pickerSource, placeholder: placeholder)
     }
     
     /// Override the `convertAnswer()` function to convert the `Measurement` returned

--- a/ResearchSuite/ResearchSuite/RSDTextInputTableItem.swift
+++ b/ResearchSuite/ResearchSuite/RSDTextInputTableItem.swift
@@ -42,7 +42,7 @@ open class RSDTextInputTableItem : RSDInputFieldTableItem {
     open private(set) var textFieldOptions: RSDTextFieldOptions?
     
     /// The placeholder text for this input.
-    open private(set) var placeholderText: String?
+    open private(set) var placeholder: String?
     
     /// The formatter used for dislaying answers and converting text to a number or date.
     open private(set) var formatter: Formatter?
@@ -62,11 +62,11 @@ open class RSDTextInputTableItem : RSDInputFieldTableItem {
     ///     - textFieldOptions: The text field options.
     ///     - formatter: The formatter used for dislaying answers and converting text to a number or date.
     ///     - pickerSource: The picker data source for selecting answers.
-    public init(rowIndex: Int, inputField: RSDInputField, uiHint: RSDFormUIHint, answerType: RSDAnswerResultType = .string, textFieldOptions: RSDTextFieldOptions? = nil, formatter: Formatter? = nil, pickerSource: RSDPickerDataSource? = nil, placeholderText: String? = nil) {
+    public init(rowIndex: Int, inputField: RSDInputField, uiHint: RSDFormUIHint, answerType: RSDAnswerResultType = .string, textFieldOptions: RSDTextFieldOptions? = nil, formatter: Formatter? = nil, pickerSource: RSDPickerDataSource? = nil, placeholder: String? = nil) {
         self.answerType = answerType
         self.formatter = formatter
         self.pickerSource = pickerSource
-        self.placeholderText = placeholderText ?? inputField.placeholderText
+        self.placeholder = placeholder ?? inputField.placeholder
         
         // Set the text field options
         self.textFieldOptions = textFieldOptions ?? inputField.textFieldOptions ?? {

--- a/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableInputFieldObjectTests.swift
+++ b/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableInputFieldObjectTests.swift
@@ -207,7 +207,7 @@ class CodableInputFieldObjectTests: XCTestCase {
         {
             "identifier": "foo",
             "prompt": "Text",
-            "placeholderText": "enter text",
+            "placeholder": "enter text",
             "dataType": "singleChoice.integer",
             "uiHint": "picker",
             "optional": true,
@@ -229,7 +229,7 @@ class CodableInputFieldObjectTests: XCTestCase {
             
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.prompt, "Text")
-            XCTAssertEqual(object.placeholderText, "enter text")
+            XCTAssertEqual(object.placeholder, "enter text")
             XCTAssertEqual(object.dataType, .collection(.singleChoice, .integer))
             XCTAssertEqual(object.uiHint, .picker)
             XCTAssertTrue(object.isOptional)
@@ -254,7 +254,7 @@ class CodableInputFieldObjectTests: XCTestCase {
             
             XCTAssertEqual(dictionary["identifier"] as? String, "foo")
             XCTAssertEqual(dictionary["prompt"] as? String, "Text")
-            XCTAssertEqual(dictionary["placeholderText"] as? String, "enter text")
+            XCTAssertEqual(dictionary["placeholder"] as? String, "enter text")
             XCTAssertEqual(dictionary["dataType"] as? String, "singleChoice.integer")
             XCTAssertEqual(dictionary["uiHint"] as? String, "picker")
             XCTAssertEqual(dictionary["optional"] as? Bool, true)

--- a/ResearchSuiteUI/ResearchSuiteUI/iOS/Step View Controllers/RSDTableStepViewController.swift
+++ b/ResearchSuiteUI/ResearchSuiteUI/iOS/Step View Controllers/RSDTableStepViewController.swift
@@ -584,7 +584,7 @@ open class RSDTableStepViewController: RSDStepViewController, UITableViewDataSou
         textFieldCell.fieldLabel.text = tableItem.inputField.prompt
         
         // populate the text field placeholder label
-        textFieldCell.placeholderText = tableItem.placeholderText
+        textFieldCell.placeholder = tableItem.placeholder
     }
     
     /// Instantiate the appropriate picker view for the given input item.

--- a/ResearchSuiteUI/ResearchSuiteUI/iOS/Views/RSDStepChoiceCell.swift
+++ b/ResearchSuiteUI/ResearchSuiteUI/iOS/Views/RSDStepChoiceCell.swift
@@ -169,7 +169,7 @@ open class RSDStepTextFieldCell: UITableViewCell {
     /// Set the string for the text field placeholder. View controllers should use this methods rather
     /// than accessing the text field's 'placeholder' directly because some subclasses may not display
     /// the placeholder text.
-    open var placeholderText: String? {
+    open var placeholder: String? {
         get {
             return textField.placeholder
         }


### PR DESCRIPTION
ResearchKit uses “placeholderText” but the actual text field uses the property key “placeholder”. This is confusing when trying to establish a JSON schema for serialization.