### PR TITLE
Add .duration data type

### DIFF
--- a/ResearchSuite/ResearchSuite.xcodeproj/project.pbxproj
+++ b/ResearchSuite/ResearchSuite.xcodeproj/project.pbxproj
@@ -91,6 +91,8 @@
 		F8586AE92011697700B2DF65 /* RSDFractionFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F8586AE52011697700B2DF65 /* RSDFractionFormatter.m */; };
 		F8586AEA2011697700B2DF65 /* RSDFractionFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F8586AE52011697700B2DF65 /* RSDFractionFormatter.m */; };
 		F8586AEB2011697700B2DF65 /* RSDFractionFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F8586AE52011697700B2DF65 /* RSDFractionFormatter.m */; };
+		F858D14B201BA67B00132325 /* MeasurementDurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F858D14A201BA67B00132325 /* MeasurementDurationTests.swift */; };
+		F858D14C201BA67B00132325 /* MeasurementDurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F858D14A201BA67B00132325 /* MeasurementDurationTests.swift */; };
 		F87F97C520059B100013D2DC /* RSDErrorResultObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87F97C420059B100013D2DC /* RSDErrorResultObject.swift */; };
 		F87F97C620059B100013D2DC /* RSDErrorResultObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87F97C420059B100013D2DC /* RSDErrorResultObject.swift */; };
 		F87F97C720059B100013D2DC /* RSDErrorResultObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87F97C420059B100013D2DC /* RSDErrorResultObject.swift */; };
@@ -100,6 +102,12 @@
 		F8904D491FF711A7002CE2EB /* RSDUnitConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8904D481FF711A7002CE2EB /* RSDUnitConverter.swift */; };
 		F8904D4A1FF711A7002CE2EB /* RSDUnitConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8904D481FF711A7002CE2EB /* RSDUnitConverter.swift */; };
 		F8904D4B1FF711A7002CE2EB /* RSDUnitConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8904D481FF711A7002CE2EB /* RSDUnitConverter.swift */; };
+		F89CA1F12023EF9C00C5EB86 /* RSDDurationFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = F89CA1EF2023EF9C00C5EB86 /* RSDDurationFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F89CA1F22023EF9C00C5EB86 /* RSDDurationFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = F89CA1EF2023EF9C00C5EB86 /* RSDDurationFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F89CA1F32023EF9C00C5EB86 /* RSDDurationFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = F89CA1EF2023EF9C00C5EB86 /* RSDDurationFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F89CA1F42023EF9C00C5EB86 /* RSDDurationFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F89CA1F02023EF9C00C5EB86 /* RSDDurationFormatter.m */; };
+		F89CA1F52023EF9C00C5EB86 /* RSDDurationFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F89CA1F02023EF9C00C5EB86 /* RSDDurationFormatter.m */; };
+		F89CA1F62023EF9C00C5EB86 /* RSDDurationFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F89CA1F02023EF9C00C5EB86 /* RSDDurationFormatter.m */; };
 		F8A5E15D1FFD6E5700D337A5 /* RSDMeasurementWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A5E15B1FFD6E5700D337A5 /* RSDMeasurementWrapper.h */; };
 		F8A5E15E1FFD6E5700D337A5 /* RSDMeasurementWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A5E15B1FFD6E5700D337A5 /* RSDMeasurementWrapper.h */; };
 		F8A5E15F1FFD6E5700D337A5 /* RSDMeasurementWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F8A5E15B1FFD6E5700D337A5 /* RSDMeasurementWrapper.h */; };
@@ -109,6 +117,15 @@
 		F8B42BE31FE9ABE200E23783 /* Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B42BE21FE9ABE200E23783 /* Localization.swift */; };
 		F8B42BE41FE9ABE200E23783 /* Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B42BE21FE9ABE200E23783 /* Localization.swift */; };
 		F8B42BE51FE9ABE200E23783 /* Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B42BE21FE9ABE200E23783 /* Localization.swift */; };
+		F8F561E72023C2A8000EEA8C /* RSDDurationPickerDataSourceObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8321EB7201AB7F900074DFA /* RSDDurationPickerDataSourceObject.swift */; };
+		F8F561E82023C2A9000EEA8C /* RSDDurationPickerDataSourceObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8321EB7201AB7F900074DFA /* RSDDurationPickerDataSourceObject.swift */; };
+		F8F561E92023C2A9000EEA8C /* RSDDurationPickerDataSourceObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8321EB7201AB7F900074DFA /* RSDDurationPickerDataSourceObject.swift */; };
+		F8F9544220239E8F00347940 /* RSDDateRangeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F9544120239E8F00347940 /* RSDDateRangeObject.swift */; };
+		F8F9544320239E8F00347940 /* RSDDateRangeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F9544120239E8F00347940 /* RSDDateRangeObject.swift */; };
+		F8F9544420239E8F00347940 /* RSDDateRangeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F9544120239E8F00347940 /* RSDDateRangeObject.swift */; };
+		F8F9544620239ED400347940 /* RSDNumberRangeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F9544520239ED400347940 /* RSDNumberRangeObject.swift */; };
+		F8F9544720239ED400347940 /* RSDNumberRangeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F9544520239ED400347940 /* RSDNumberRangeObject.swift */; };
+		F8F9544820239ED400347940 /* RSDNumberRangeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F9544520239ED400347940 /* RSDNumberRangeObject.swift */; };
 		FF52BCB31FD8884200DB3322 /* RSDDataLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF52BCB21FD8884200DB3322 /* RSDDataLogger.swift */; };
 		FF52BCB41FD8884200DB3322 /* RSDDataLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF52BCB21FD8884200DB3322 /* RSDDataLogger.swift */; };
 		FF52BCB51FD8884200DB3322 /* RSDDataLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF52BCB21FD8884200DB3322 /* RSDDataLogger.swift */; };
@@ -290,20 +307,20 @@
 		FF8B543D1FCE6CA9006B6937 /* RSDComparableSurveyRuleObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF63E83C1FBAE5C80060DD98 /* RSDComparableSurveyRuleObject.swift */; };
 		FF8B543E1FCE6CA9006B6937 /* RSDInputFieldObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6A4AA1F85941F00E37752 /* RSDInputFieldObject.swift */; };
 		FF8B543F1FCE6CA9006B6937 /* RSDMultipleComponentInputFieldObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6A4B61F85F38800E37752 /* RSDMultipleComponentInputFieldObject.swift */; };
-		FF8B54401FCE6CA9006B6937 /* RSDRangeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6A4B81F8607C300E37752 /* RSDRangeObject.swift */; };
+		FF8B54401FCE6CA9006B6937 /* RSDDurationRangeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6A4B81F8607C300E37752 /* RSDDurationRangeObject.swift */; };
 		FF8B54411FCE6CA9006B6937 /* RSDTextFieldOptionsObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE0DE4B1F86E39F00BB1BDF /* RSDTextFieldOptionsObject.swift */; };
 		FF8B54421FCE6CAA006B6937 /* RSDChoiceObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBA00031F85657C0079A404 /* RSDChoiceObject.swift */; };
 		FF8B54431FCE6CAA006B6937 /* RSDChoiceInputFieldObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6A4AC1F859B0100E37752 /* RSDChoiceInputFieldObject.swift */; };
 		FF8B54441FCE6CAA006B6937 /* RSDComparableSurveyRuleObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF63E83C1FBAE5C80060DD98 /* RSDComparableSurveyRuleObject.swift */; };
 		FF8B54451FCE6CAA006B6937 /* RSDInputFieldObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6A4AA1F85941F00E37752 /* RSDInputFieldObject.swift */; };
 		FF8B54461FCE6CAA006B6937 /* RSDMultipleComponentInputFieldObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6A4B61F85F38800E37752 /* RSDMultipleComponentInputFieldObject.swift */; };
-		FF8B54471FCE6CAA006B6937 /* RSDRangeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6A4B81F8607C300E37752 /* RSDRangeObject.swift */; };
+		FF8B54471FCE6CAA006B6937 /* RSDDurationRangeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6A4B81F8607C300E37752 /* RSDDurationRangeObject.swift */; };
 		FF8B54491FCE6CAA006B6937 /* RSDChoiceObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBA00031F85657C0079A404 /* RSDChoiceObject.swift */; };
 		FF8B544A1FCE6CAA006B6937 /* RSDChoiceInputFieldObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6A4AC1F859B0100E37752 /* RSDChoiceInputFieldObject.swift */; };
 		FF8B544B1FCE6CAA006B6937 /* RSDComparableSurveyRuleObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF63E83C1FBAE5C80060DD98 /* RSDComparableSurveyRuleObject.swift */; };
 		FF8B544C1FCE6CAA006B6937 /* RSDInputFieldObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6A4AA1F85941F00E37752 /* RSDInputFieldObject.swift */; };
 		FF8B544D1FCE6CAA006B6937 /* RSDMultipleComponentInputFieldObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6A4B61F85F38800E37752 /* RSDMultipleComponentInputFieldObject.swift */; };
-		FF8B544E1FCE6CAA006B6937 /* RSDRangeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6A4B81F8607C300E37752 /* RSDRangeObject.swift */; };
+		FF8B544E1FCE6CAA006B6937 /* RSDDurationRangeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6A4B81F8607C300E37752 /* RSDDurationRangeObject.swift */; };
 		FF8B544F1FCE6CAA006B6937 /* RSDTextFieldOptionsObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE0DE4B1F86E39F00BB1BDF /* RSDTextFieldOptionsObject.swift */; };
 		FF8B54571FCE6CB1006B6937 /* RSDUIActionObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF269B711F7E128700C9289E /* RSDUIActionObject.swift */; };
 		FF8B54581FCE6CB1006B6937 /* RSDUIActionHandlerObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF427CE71FA3B247005A5AD2 /* RSDUIActionHandlerObject.swift */; };
@@ -465,15 +482,21 @@
 		F829F0ED1FFC0544001B0680 /* ResearchSuiteTests_tvOS-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ResearchSuiteTests_tvOS-Bridging-Header.h"; sourceTree = "<group>"; };
 		F829F0F41FFC0B2B001B0680 /* NSLocale+UnitTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSLocale+UnitTest.h"; sourceTree = "<group>"; };
 		F829F0F51FFC0B2B001B0680 /* NSLocale+UnitTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSLocale+UnitTest.m"; sourceTree = "<group>"; };
+		F8321EB7201AB7F900074DFA /* RSDDurationPickerDataSourceObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDDurationPickerDataSourceObject.swift; sourceTree = "<group>"; };
 		F84E54531FE9BC4B0058F0CD /* StaticUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StaticUtilities.swift; sourceTree = "<group>"; };
 		F8586AE42011697700B2DF65 /* RSDFractionFormatter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RSDFractionFormatter.h; sourceTree = "<group>"; };
 		F8586AE52011697700B2DF65 /* RSDFractionFormatter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RSDFractionFormatter.m; sourceTree = "<group>"; };
+		F858D14A201BA67B00132325 /* MeasurementDurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementDurationTests.swift; sourceTree = "<group>"; };
 		F87F97C420059B100013D2DC /* RSDErrorResultObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDErrorResultObject.swift; sourceTree = "<group>"; };
 		F88051A12011B43700B0FDDD /* RSDFraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDFraction.swift; sourceTree = "<group>"; };
 		F8904D481FF711A7002CE2EB /* RSDUnitConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDUnitConverter.swift; sourceTree = "<group>"; };
+		F89CA1EF2023EF9C00C5EB86 /* RSDDurationFormatter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RSDDurationFormatter.h; sourceTree = "<group>"; };
+		F89CA1F02023EF9C00C5EB86 /* RSDDurationFormatter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RSDDurationFormatter.m; sourceTree = "<group>"; };
 		F8A5E15B1FFD6E5700D337A5 /* RSDMeasurementWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RSDMeasurementWrapper.h; sourceTree = "<group>"; };
 		F8A5E15C1FFD6E5700D337A5 /* RSDMeasurementWrapper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RSDMeasurementWrapper.m; sourceTree = "<group>"; };
 		F8B42BE21FE9ABE200E23783 /* Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Localization.swift; sourceTree = "<group>"; };
+		F8F9544120239E8F00347940 /* RSDDateRangeObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDDateRangeObject.swift; sourceTree = "<group>"; };
+		F8F9544520239ED400347940 /* RSDNumberRangeObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDNumberRangeObject.swift; sourceTree = "<group>"; };
 		FF0920BE1FCE310500C9E031 /* RSDTableSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDTableSection.swift; sourceTree = "<group>"; };
 		FF0920C01FCE37AD00C9E031 /* RSDTableItemGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDTableItemGroup.swift; sourceTree = "<group>"; };
 		FF0920C21FCE3F0300C9E031 /* RSDTableItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDTableItem.swift; sourceTree = "<group>"; };
@@ -559,7 +582,7 @@
 		FFB6A4AA1F85941F00E37752 /* RSDInputFieldObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDInputFieldObject.swift; sourceTree = "<group>"; };
 		FFB6A4AC1F859B0100E37752 /* RSDChoiceInputFieldObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDChoiceInputFieldObject.swift; sourceTree = "<group>"; };
 		FFB6A4B61F85F38800E37752 /* RSDMultipleComponentInputFieldObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDMultipleComponentInputFieldObject.swift; sourceTree = "<group>"; };
-		FFB6A4B81F8607C300E37752 /* RSDRangeObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDRangeObject.swift; sourceTree = "<group>"; };
+		FFB6A4B81F8607C300E37752 /* RSDDurationRangeObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDDurationRangeObject.swift; sourceTree = "<group>"; };
 		FFBA00031F85657C0079A404 /* RSDChoiceObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDChoiceObject.swift; sourceTree = "<group>"; };
 		FFBD07351FAA3E4B000CB34F /* RSDSectionStepTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDSectionStepTransformer.swift; sourceTree = "<group>"; };
 		FFBD07371FAA46CD000CB34F /* RSDTransformerStepObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDTransformerStepObject.swift; sourceTree = "<group>"; };
@@ -642,6 +665,7 @@
 				FFC7DE5D1F992EA800851C95 /* RSDMultipleComponentOptionsObject.swift */,
 				F80CA5091FFEAB2100E89C06 /* RSDNumberPickerDataSourceObject.swift */,
 				F80CA51A1FFEAD1F00E89C06 /* RSDUSMeasurementPickerDataSource.swift */,
+				F8321EB7201AB7F900074DFA /* RSDDurationPickerDataSourceObject.swift */,
 			);
 			name = PickerDataSource;
 			sourceTree = "<group>";
@@ -685,6 +709,8 @@
 			children = (
 				F8586AE42011697700B2DF65 /* RSDFractionFormatter.h */,
 				F8586AE52011697700B2DF65 /* RSDFractionFormatter.m */,
+				F89CA1EF2023EF9C00C5EB86 /* RSDDurationFormatter.h */,
+				F89CA1F02023EF9C00C5EB86 /* RSDDurationFormatter.m */,
 				F829F0CE1FF71EE7001B0680 /* RSDLengthFormatter.h */,
 				F829F0CF1FF71EE7001B0680 /* RSDLengthFormatter.m */,
 				F829F0D61FF86DA4001B0680 /* RSDMassFormatter.h */,
@@ -704,6 +730,24 @@
 				F829F0F51FFC0B2B001B0680 /* NSLocale+UnitTest.m */,
 			);
 			path = "Mock Objects";
+			sourceTree = "<group>";
+		};
+		F858D149201BA61A00132325 /* ModelObject Tests */ = {
+			isa = PBXGroup;
+			children = (
+				F858D14A201BA67B00132325 /* MeasurementDurationTests.swift */,
+			);
+			path = "ModelObject Tests";
+			sourceTree = "<group>";
+		};
+		F8F9544020239E5D00347940 /* Range */ = {
+			isa = PBXGroup;
+			children = (
+				F8F9544120239E8F00347940 /* RSDDateRangeObject.swift */,
+				F8F9544520239ED400347940 /* RSDNumberRangeObject.swift */,
+				FFB6A4B81F8607C300E37752 /* RSDDurationRangeObject.swift */,
+			);
+			name = Range;
 			sourceTree = "<group>";
 		};
 		FF0920BD1FCE226500C9E031 /* Objects */ = {
@@ -846,6 +890,7 @@
 				FF87CD821F84110800084426 /* Test files */,
 				FF2DA6181F96E7C4006F83C4 /* Codable Tests */,
 				F829F0C41FF71C45001B0680 /* DataSource Tests */,
+				F858D149201BA61A00132325 /* ModelObject Tests */,
 				FF2ACF401FBB86870018D87F /* Navigation Tests */,
 			);
 			path = ResearchSuiteTests;
@@ -967,12 +1012,12 @@
 		FFBA00021F8563C10079A404 /* InputField */ = {
 			isa = PBXGroup;
 			children = (
+				F8F9544020239E5D00347940 /* Range */,
 				FFBA00031F85657C0079A404 /* RSDChoiceObject.swift */,
 				FFB6A4AC1F859B0100E37752 /* RSDChoiceInputFieldObject.swift */,
 				FF63E83C1FBAE5C80060DD98 /* RSDComparableSurveyRuleObject.swift */,
 				FFB6A4AA1F85941F00E37752 /* RSDInputFieldObject.swift */,
 				FFB6A4B61F85F38800E37752 /* RSDMultipleComponentInputFieldObject.swift */,
-				FFB6A4B81F8607C300E37752 /* RSDRangeObject.swift */,
 				FFE0DE4B1F86E39F00BB1BDF /* RSDTextFieldOptionsObject.swift */,
 			);
 			name = InputField;
@@ -1016,8 +1061,8 @@
 				FF87CD8B1F844CE400084426 /* RSDFormUIHint.swift */,
 				F88051A12011B43700B0FDDD /* RSDFraction.swift */,
 				FF80B1381F7C244200582849 /* RSDIdentifier.swift */,
-				FFB015DF1F8C081200AC209B /* RSDStandardPermissionType.swift */,
 				FFF53EAC1FBF9562004211D2 /* RSDResultType.swift */,
+				FFB015DF1F8C081200AC209B /* RSDStandardPermissionType.swift */,
 				FFD38DE61FBF805F004203D8 /* RSDStepType.swift */,
 			);
 			name = Types;
@@ -1070,6 +1115,7 @@
 				FF8B53711FCE6940006B6937 /* ResearchSuite.h in Headers */,
 				FF8B54ED1FCE6D15006B6937 /* RSDExceptionHandler.h in Headers */,
 				F8A5E15D1FFD6E5700D337A5 /* RSDMeasurementWrapper.h in Headers */,
+				F89CA1F12023EF9C00C5EB86 /* RSDDurationFormatter.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1084,6 +1130,7 @@
 				FF8B53721FCE6942006B6937 /* ResearchSuite.h in Headers */,
 				FF8B54E61FCE6D14006B6937 /* RSDExceptionHandler.h in Headers */,
 				F8A5E15E1FFD6E5700D337A5 /* RSDMeasurementWrapper.h in Headers */,
+				F89CA1F22023EF9C00C5EB86 /* RSDDurationFormatter.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1098,6 +1145,7 @@
 				FF8B53731FCE6943006B6937 /* ResearchSuite.h in Headers */,
 				FF8B54DF1FCE6D14006B6937 /* RSDExceptionHandler.h in Headers */,
 				F8A5E15F1FFD6E5700D337A5 /* RSDMeasurementWrapper.h in Headers */,
+				F89CA1F32023EF9C00C5EB86 /* RSDDurationFormatter.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1335,6 +1383,7 @@
 				FF8B53A91FCE6C7A006B6937 /* RSDSchemaInfo.swift in Sources */,
 				F87F97C520059B100013D2DC /* RSDErrorResultObject.swift in Sources */,
 				FF8B54EB1FCE6D15006B6937 /* SequenceType+Utilities.swift in Sources */,
+				F8F9544220239E8F00347940 /* RSDDateRangeObject.swift in Sources */,
 				FF8B54411FCE6CA9006B6937 /* RSDTextFieldOptionsObject.swift in Sources */,
 				FF8B53F71FCE6C86006B6937 /* RSDImageWrapper.swift in Sources */,
 				FF8B54941FCE6CEC006B6937 /* RSDPickerDataSource.swift in Sources */,
@@ -1354,10 +1403,11 @@
 				FF8B545F1FCE6CB8006B6937 /* RSDColorThemeElementObject.swift in Sources */,
 				FF8B53B21FCE6C7A006B6937 /* RSDTaskTransformer.swift in Sources */,
 				FF8B543F1FCE6CA9006B6937 /* RSDMultipleComponentInputFieldObject.swift in Sources */,
-				FF8B54401FCE6CA9006B6937 /* RSDRangeObject.swift in Sources */,
+				FF8B54401FCE6CA9006B6937 /* RSDDurationRangeObject.swift in Sources */,
 				FF8B547F1FCE6CD3006B6937 /* RSDTaskPath.swift in Sources */,
 				FF8B543B1FCE6CA9006B6937 /* RSDChoiceObject.swift in Sources */,
 				FF8B54A41FCE6CF7006B6937 /* RSDTableItemGroup.swift in Sources */,
+				F8F9544620239ED400347940 /* RSDNumberRangeObject.swift in Sources */,
 				FF8B53A21FCE6C7A006B6937 /* RSDAsyncActionConfiguration.swift in Sources */,
 				FF8B548C1FCE6CDD006B6937 /* RSDAsyncActionController.swift in Sources */,
 				FF8B54571FCE6CB1006B6937 /* RSDUIActionObject.swift in Sources */,
@@ -1377,6 +1427,7 @@
 				FF8B546B1FCE6CC5006B6937 /* RSDConditionalStepNavigatorObject.swift in Sources */,
 				FF8B53B51FCE6C7A006B6937 /* RSDUIAction.swift in Sources */,
 				FF8B53831FCE6C6F006B6937 /* RSDIdentifier.swift in Sources */,
+				F89CA1F42023EF9C00C5EB86 /* RSDDurationFormatter.m in Sources */,
 				F80CA5281FFEBD7600E89C06 /* RSDTextInputTableItem.swift in Sources */,
 				FF8B546E1FCE6CC5006B6937 /* RSDTaskInfoStepObject.swift in Sources */,
 				F8586AE92011697700B2DF65 /* RSDFractionFormatter.m in Sources */,
@@ -1399,6 +1450,7 @@
 				F80CA52C1FFEBDCF00E89C06 /* RSDNumberInputTableItem.swift in Sources */,
 				FF8B54A11FCE6CF6006B6937 /* RSDMultipleComponentOptionsObject.swift in Sources */,
 				FF8B53851FCE6C6F006B6937 /* RSDResultType.swift in Sources */,
+				F8F561E72023C2A8000EEA8C /* RSDDurationPickerDataSourceObject.swift in Sources */,
 				FF8B54261FCE6CA2006B6937 /* RSDSectionStepObject.swift in Sources */,
 				FF8B53AF1FCE6C7A006B6937 /* RSDSurveyRule.swift in Sources */,
 				FF8B549F1FCE6CF6006B6937 /* RSDFormStepDataSourceObject.swift in Sources */,
@@ -1442,6 +1494,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F858D14B201BA67B00132325 /* MeasurementDurationTests.swift in Sources */,
 				FF633D751FCE7A6900CF2267 /* CodableResultObjectTests.swift in Sources */,
 				FF633D731FCE7A6900CF2267 /* CodableTestObjects.swift in Sources */,
 				F829F0EA1FFB4620001B0680 /* PickerDataSourceTests.swift in Sources */,
@@ -1477,6 +1530,7 @@
 				FF8B53BE1FCE6C7B006B6937 /* RSDSchemaInfo.swift in Sources */,
 				F87F97C620059B100013D2DC /* RSDErrorResultObject.swift in Sources */,
 				FF8B54E41FCE6D14006B6937 /* SequenceType+Utilities.swift in Sources */,
+				F8F9544320239E8F00347940 /* RSDDateRangeObject.swift in Sources */,
 				FF8B53FB1FCE6C87006B6937 /* RSDImageWrapper.swift in Sources */,
 				FF8B54971FCE6CED006B6937 /* RSDPickerDataSource.swift in Sources */,
 				FF8B53C81FCE6C7B006B6937 /* RSDTextFieldOptions.swift in Sources */,
@@ -1495,11 +1549,12 @@
 				FF8B54621FCE6CB9006B6937 /* RSDColorThemeElementObject.swift in Sources */,
 				FF8B53C71FCE6C7B006B6937 /* RSDTaskTransformer.swift in Sources */,
 				FF8B54461FCE6CAA006B6937 /* RSDMultipleComponentInputFieldObject.swift in Sources */,
-				FF8B54471FCE6CAA006B6937 /* RSDRangeObject.swift in Sources */,
+				FF8B54471FCE6CAA006B6937 /* RSDDurationRangeObject.swift in Sources */,
 				FF8B54801FCE6CD4006B6937 /* RSDTaskPath.swift in Sources */,
 				FF8B54421FCE6CAA006B6937 /* RSDChoiceObject.swift in Sources */,
 				FF8B54AA1FCE6CF7006B6937 /* RSDTableItemGroup.swift in Sources */,
 				FF8B53B71FCE6C7B006B6937 /* RSDAsyncActionConfiguration.swift in Sources */,
+				F8F9544720239ED400347940 /* RSDNumberRangeObject.swift in Sources */,
 				FF8B54891FCE6CDD006B6937 /* RSDAsyncActionController.swift in Sources */,
 				FF8B54591FCE6CB2006B6937 /* RSDUIActionObject.swift in Sources */,
 				FF8B54E11FCE6D14006B6937 /* Array+Utilities.swift in Sources */,
@@ -1519,6 +1574,7 @@
 				FF8B53CA1FCE6C7B006B6937 /* RSDUIAction.swift in Sources */,
 				FFEF95631FCE8D06008C30A6 /* RSDTextFieldOptionsObject.swift in Sources */,
 				FF8B538C1FCE6C70006B6937 /* RSDIdentifier.swift in Sources */,
+				F89CA1F52023EF9C00C5EB86 /* RSDDurationFormatter.m in Sources */,
 				F80CA5291FFEBD7600E89C06 /* RSDTextInputTableItem.swift in Sources */,
 				FF8B54731FCE6CC5006B6937 /* RSDTaskInfoStepObject.swift in Sources */,
 				F8586AEA2011697700B2DF65 /* RSDFractionFormatter.m in Sources */,
@@ -1541,6 +1597,7 @@
 				F80CA52D1FFEBDCF00E89C06 /* RSDNumberInputTableItem.swift in Sources */,
 				FF8B538E1FCE6C70006B6937 /* RSDResultType.swift in Sources */,
 				FF8B542C1FCE6CA2006B6937 /* RSDSectionStepObject.swift in Sources */,
+				F8F561E82023C2A9000EEA8C /* RSDDurationPickerDataSourceObject.swift in Sources */,
 				FF8B53C41FCE6C7B006B6937 /* RSDSurveyRule.swift in Sources */,
 				FF8B54A51FCE6CF7006B6937 /* RSDFormStepDataSourceObject.swift in Sources */,
 				FF8B53BA1FCE6C7B006B6937 /* RSDInputField.swift in Sources */,
@@ -1615,13 +1672,14 @@
 				F80CA52E1FFEBDCF00E89C06 /* RSDNumberInputTableItem.swift in Sources */,
 				FF8B53DC1FCE6C7B006B6937 /* RSDTaskTransformer.swift in Sources */,
 				FF8B544D1FCE6CAA006B6937 /* RSDMultipleComponentInputFieldObject.swift in Sources */,
-				FF8B544E1FCE6CAA006B6937 /* RSDRangeObject.swift in Sources */,
+				FF8B544E1FCE6CAA006B6937 /* RSDDurationRangeObject.swift in Sources */,
 				FF8B54811FCE6CD5006B6937 /* RSDTaskPath.swift in Sources */,
 				FF8B54491FCE6CAA006B6937 /* RSDChoiceObject.swift in Sources */,
 				FF8B54B01FCE6CF8006B6937 /* RSDTableItemGroup.swift in Sources */,
 				FF8B53CC1FCE6C7B006B6937 /* RSDAsyncActionConfiguration.swift in Sources */,
 				FF8B54861FCE6CDC006B6937 /* RSDAsyncActionController.swift in Sources */,
 				FF8B545B1FCE6CB2006B6937 /* RSDUIActionObject.swift in Sources */,
+				F8F9544820239ED400347940 /* RSDNumberRangeObject.swift in Sources */,
 				FF8B54DA1FCE6D14006B6937 /* Array+Utilities.swift in Sources */,
 				F8586AEB2011697700B2DF65 /* RSDFractionFormatter.m in Sources */,
 				FF8B53981FCE6C71006B6937 /* RSDStepType.swift in Sources */,
@@ -1659,6 +1717,7 @@
 				FF8B54911FCE6CE3006B6937 /* RSDSampleRecorder.swift in Sources */,
 				FF8B54AD1FCE6CF8006B6937 /* RSDMultipleComponentOptionsObject.swift in Sources */,
 				FF8B53971FCE6C71006B6937 /* RSDResultType.swift in Sources */,
+				F89CA1F62023EF9C00C5EB86 /* RSDDurationFormatter.m in Sources */,
 				FF8B54321FCE6CA3006B6937 /* RSDSectionStepObject.swift in Sources */,
 				FF8B53D91FCE6C7B006B6937 /* RSDSurveyRule.swift in Sources */,
 				F80CA53B1FFEBF6800E89C06 /* RSDInputFieldTableItemGroup.swift in Sources */,
@@ -1672,6 +1731,7 @@
 				FF8B53901FCE6C71006B6937 /* RSDActiveUIStepCommand.swift in Sources */,
 				FF8B53D61FCE6C7B006B6937 /* RSDStepNavigator.swift in Sources */,
 				FF8B53D01FCE6C7B006B6937 /* RSDRange.swift in Sources */,
+				F8F561E92023C2A9000EEA8C /* RSDDurationPickerDataSourceObject.swift in Sources */,
 				FF8B54CA1FCE6D0B006B6937 /* RSDJSONNumber.swift in Sources */,
 				F80CA5371FFEBEFE00E89C06 /* RSDChoicePickerTableItemGroup.swift in Sources */,
 				FF8B541A1FCE6C9A006B6937 /* RSDFileResultObject.swift in Sources */,
@@ -1681,6 +1741,7 @@
 				FF8B53961FCE6C71006B6937 /* RSDStandardPermissionType.swift in Sources */,
 				FF8B54671FCE6CB9006B6937 /* RSDViewThemeElementObject.swift in Sources */,
 				F8B42BE51FE9ABE200E23783 /* Localization.swift in Sources */,
+				F8F9544420239E8F00347940 /* RSDDateRangeObject.swift in Sources */,
 				F80CA5321FFEBE3200E89C06 /* RSDMeasurementInputTableItem.swift in Sources */,
 				FF8B54191FCE6C9A006B6937 /* RSDAnswerResultObject.swift in Sources */,
 				FF8B54081FCE6C8F006B6937 /* RSDStandardAsyncActionConfiguration.swift in Sources */,
@@ -1705,6 +1766,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F858D14C201BA67B00132325 /* MeasurementDurationTests.swift in Sources */,
 				FF633D7C1FCE7A6A00CF2267 /* CodableResultObjectTests.swift in Sources */,
 				F829F0F71FFC0B2B001B0680 /* NSLocale+UnitTest.m in Sources */,
 				FF633D7A1FCE7A6A00CF2267 /* CodableTestObjects.swift in Sources */,

--- a/ResearchSuite/ResearchSuite.xcodeproj/project.pbxproj
+++ b/ResearchSuite/ResearchSuite.xcodeproj/project.pbxproj
@@ -57,7 +57,6 @@
 		F818EAC6201948D0001C9FE4 /* TableItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F818EAC5201948D0001C9FE4 /* TableItemTests.swift */; };
 		F818EAC7201948D0001C9FE4 /* TableItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F818EAC5201948D0001C9FE4 /* TableItemTests.swift */; };
 		F829F0C61FF71C7B001B0680 /* FormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F829F0C51FF71C7B001B0680 /* FormatterTests.swift */; };
-		F829F0C71FF71C7B001B0680 /* FormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F829F0C51FF71C7B001B0680 /* FormatterTests.swift */; };
 		F829F0D01FF71EE7001B0680 /* RSDLengthFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = F829F0CE1FF71EE7001B0680 /* RSDLengthFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F829F0D11FF71EE7001B0680 /* RSDLengthFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = F829F0CE1FF71EE7001B0680 /* RSDLengthFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F829F0D21FF71EE7001B0680 /* RSDLengthFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = F829F0CE1FF71EE7001B0680 /* RSDLengthFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -71,7 +70,6 @@
 		F829F0DC1FF86DA4001B0680 /* RSDMassFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F829F0D71FF86DA4001B0680 /* RSDMassFormatter.m */; };
 		F829F0DD1FF86DA4001B0680 /* RSDMassFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F829F0D71FF86DA4001B0680 /* RSDMassFormatter.m */; };
 		F829F0DF1FF887C3001B0680 /* UnitConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F829F0DE1FF887C3001B0680 /* UnitConversionTests.swift */; };
-		F829F0E01FF887C3001B0680 /* UnitConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F829F0DE1FF887C3001B0680 /* UnitConversionTests.swift */; };
 		F829F0E31FF8AF28001B0680 /* NSUnit+RSDUnitConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = F829F0E11FF8AF28001B0680 /* NSUnit+RSDUnitConversion.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F829F0E41FF8AF28001B0680 /* NSUnit+RSDUnitConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = F829F0E11FF8AF28001B0680 /* NSUnit+RSDUnitConversion.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F829F0E51FF8AF28001B0680 /* NSUnit+RSDUnitConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = F829F0E11FF8AF28001B0680 /* NSUnit+RSDUnitConversion.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -114,6 +112,8 @@
 		F8A5E1601FFD6E5700D337A5 /* RSDMeasurementWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = F8A5E15C1FFD6E5700D337A5 /* RSDMeasurementWrapper.m */; };
 		F8A5E1611FFD6E5700D337A5 /* RSDMeasurementWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = F8A5E15C1FFD6E5700D337A5 /* RSDMeasurementWrapper.m */; };
 		F8A5E1621FFD6E5700D337A5 /* RSDMeasurementWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = F8A5E15C1FFD6E5700D337A5 /* RSDMeasurementWrapper.m */; };
+		F8A794ED2028F56E0078068B /* FormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F829F0C51FF71C7B001B0680 /* FormatterTests.swift */; };
+		F8A794EE2028F5770078068B /* UnitConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F829F0DE1FF887C3001B0680 /* UnitConversionTests.swift */; };
 		F8B42BE31FE9ABE200E23783 /* Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B42BE21FE9ABE200E23783 /* Localization.swift */; };
 		F8B42BE41FE9ABE200E23783 /* Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B42BE21FE9ABE200E23783 /* Localization.swift */; };
 		F8B42BE51FE9ABE200E23783 /* Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B42BE21FE9ABE200E23783 /* Localization.swift */; };
@@ -1647,7 +1647,6 @@
 				FF8B54791FCE6CC6006B6937 /* RSDTaskObject.swift in Sources */,
 				FF8B54771FCE6CC6006B6937 /* RSDTaskGroupObject.swift in Sources */,
 				FF8B53D81FCE6C7B006B6937 /* RSDSurveyNavigationStep.swift in Sources */,
-				F829F0E01FF887C3001B0680 /* UnitConversionTests.swift in Sources */,
 				FF8B54991FCE6CEE006B6937 /* RSDFormStepDataSource.swift in Sources */,
 				F80CA5101FFEAB8D00E89C06 /* RSDDatePickerDataSourceObject.swift in Sources */,
 				F80CA50C1FFEAB2100E89C06 /* RSDNumberPickerDataSourceObject.swift in Sources */,
@@ -1755,7 +1754,6 @@
 				FF8B53FE1FCE6C87006B6937 /* RSDDateCoderObject.swift in Sources */,
 				FF8B53CE1FCE6C7B006B6937 /* RSDDateCoder.swift in Sources */,
 				FF8B54CB1FCE6D0B006B6937 /* RSDJSONValue.swift in Sources */,
-				F829F0C71FF71C7B001B0680 /* FormatterTests.swift in Sources */,
 				FF8B54341FCE6CA3006B6937 /* RSDTransformerStepObject.swift in Sources */,
 				FF8B544C1FCE6CAA006B6937 /* RSDInputFieldObject.swift in Sources */,
 				F80CA51D1FFEAD1F00E89C06 /* RSDUSMeasurementPickerDataSource.swift in Sources */,
@@ -1772,7 +1770,9 @@
 				FF633D7A1FCE7A6A00CF2267 /* CodableTestObjects.swift in Sources */,
 				F829F0EB1FFB4620001B0680 /* PickerDataSourceTests.swift in Sources */,
 				FF633D7B1FCE7A6A00CF2267 /* CodableInputFieldObjectTests.swift in Sources */,
+				F8A794ED2028F56E0078068B /* FormatterTests.swift in Sources */,
 				FF633D911FCE7A7400CF2267 /* StepControllerTests.swift in Sources */,
+				F8A794EE2028F5770078068B /* UnitConversionTests.swift in Sources */,
 				FF633D901FCE7A7400CF2267 /* NavigationTestObjects.swift in Sources */,
 				F818EAC7201948D0001C9FE4 /* TableItemTests.swift in Sources */,
 				FF633D7E1FCE7A6A00CF2267 /* CodableTaskObjectTests.swift in Sources */,

--- a/ResearchSuite/ResearchSuite/NSUnit+RSDUnitConversion.m
+++ b/ResearchSuite/ResearchSuite/NSUnit+RSDUnitConversion.m
@@ -132,3 +132,43 @@
 }
 
 @end
+
+@implementation NSUnitDuration (RSDUnitConversion)
+
+/// Convert the symbol into a unit of duration.
+/// @param symbol   The symbol for the unit.
++ (NSUnitDuration * _Nullable)unitDurationFromSymbol:(NSString *)symbol {
+    NSString *searchSymbol = [symbol stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    for (NSUnitDuration *unit in [self units]) {
+        if ([unit.symbol isEqualToString:searchSymbol]) {
+            return unit;
+        }
+    }
+    return [self longUnits][symbol];
+}
+
++ (NSArray <NSUnitDuration *> *)units {
+    static dispatch_once_t once;
+    static NSArray <NSUnitDuration *> * units;
+    dispatch_once(&once, ^{
+        units = @[NSUnitDuration.seconds,
+                  NSUnitDuration.minutes,
+                  NSUnitDuration.hours
+                  ];
+    });
+    return units;
+}
+
++ (NSDictionary <NSString *, NSUnitDuration *> *)longUnits {
+    static dispatch_once_t once;
+    static NSDictionary <NSString *, NSUnitDuration *> * longUnits;
+    dispatch_once(&once, ^{
+        longUnits = @{ @"seconds" : NSUnitDuration.seconds,
+                       @"minutes" : NSUnitDuration.minutes,
+                       @"hours" : NSUnitDuration.hours
+                       };
+    });
+    return longUnits;
+}
+
+@end

--- a/ResearchSuite/ResearchSuite/RSDAnswerResultType.swift
+++ b/ResearchSuite/ResearchSuite/RSDAnswerResultType.swift
@@ -46,7 +46,7 @@ public struct RSDAnswerResultType : Codable {
     /// The base type of the answer result. This is used to indicate what the type is of the
     /// value being stored. The value stored in the `RSDAnswerResult` should be convertable
     /// to one of these base types.
-    public enum BaseType : String, Codable {
+    public enum BaseType : String, Codable, RSDEnumSet {
         
         /// Bool
         case boolean
@@ -60,18 +60,16 @@ public struct RSDAnswerResultType : Codable {
         case integer
         /// String
         case string
-        /// TimeInterval
-        case timeInterval
         
         /// List of all the base types
-        public static func allTypes() -> [BaseType] {
-            return [.boolean, .data, .date, .decimal, .integer, .string, .timeInterval]
+        public static var all: Set<BaseType> {
+            return [.boolean, .data, .date, .decimal, .integer, .string]
         }
     }
     
     /// The sequence type of the answer result. This is used to represent a multiple-choice
     /// answer array or a key/value dictionary.
-    public enum SequenceType : String, Codable {
+    public enum SequenceType : String, Codable, RSDEnumSet {
         
         /// Array
         case array
@@ -79,7 +77,7 @@ public struct RSDAnswerResultType : Codable {
         case dictionary
         
         /// List of all the sequence types
-        public static func allTypes() -> [SequenceType] {
+        public static  var all: Set<SequenceType> {
             return [.array, .dictionary]
         }
     }
@@ -142,9 +140,6 @@ public struct RSDAnswerResultType : Codable {
     
     /// Static type for a `RSDAnswerResultType` with a `String` base type.
     public static let string = RSDAnswerResultType(baseType: .string)
-    
-    /// Static type for a `RSDAnswerResultType` with a `TimeInterval` base type.
-    public static let timeInterval = RSDAnswerResultType(baseType: .timeInterval)
     
     /// The initializer for the `RSDAnswerResultType`.
     ///
@@ -239,10 +234,6 @@ extension RSDAnswerResultType {
             
         case .date:
             return try decoder.factory.decodeDate(from: string, formatter: self.dateFormatter, codingPath: decoder.codingPath)
-            
-        case .timeInterval:
-            return (string as NSString).doubleValue
-            
         }
     }
     
@@ -272,10 +263,6 @@ extension RSDAnswerResultType {
             else {
                 return try container.decode(Date.self)
             }
-            
-        case .timeInterval:
-            return try container.decode(TimeInterval.self)
-            
         }
     }
     
@@ -382,7 +369,7 @@ extension RSDAnswerResultType {
             switch baseType {
             case .boolean:
                 return num.boolValue
-            case .decimal, .timeInterval:
+            case .decimal:
                 return num.doubleValue
             case .integer:
                 return num.intValue
@@ -422,7 +409,7 @@ extension RSDAnswerResultType {
             switch baseType {
             case .data:
                 return (value as? Data)
-            case .boolean, .decimal, .integer, .timeInterval:
+            case .boolean, .decimal, .integer:
                 return (value as? RSDJSONNumber)
             case .string:
                 return "\(value)"
@@ -450,15 +437,9 @@ extension RSDAnswerResultType : Hashable, Equatable {
 }
 
 extension RSDAnswerResultType.BaseType : RSDDocumentableEnum {
-    static func allCodingKeys() -> [String] {
-        return self.allTypes().map{ $0.rawValue }
-    }
 }
 
 extension RSDAnswerResultType.SequenceType : RSDDocumentableEnum {
-    static func allCodingKeys() -> [String] {
-        return self.allTypes().map{ $0.rawValue }
-    }
 }
 
 extension RSDAnswerResultType : RSDDocumentableCodableObject {
@@ -502,10 +483,10 @@ extension RSDAnswerResultType : RSDDocumentableCodableObject {
     static func examplesWithValues() -> [(answerType: RSDAnswerResultType, value: Any)] {
         var examples: [(RSDAnswerResultType, Any)] = []
 
-        let sequenceTypes = SequenceType.allTypes()
+        let sequenceTypes = SequenceType.all
         
         func addExamples(sequenceType: SequenceType?) {
-            let baseTypes = BaseType.allTypes()
+            let baseTypes = BaseType.all
             for baseType in baseTypes {
                 switch baseType {
                 case .boolean:
@@ -588,21 +569,6 @@ extension RSDAnswerResultType : RSDDocumentableCodableObject {
                     if sequenceType == .array {
                         examples.append((RSDAnswerResultType(baseType: baseType, sequenceType: sequenceType, formDataType: nil, dateFormat: nil, unit: nil, sequenceSeparator: "/"), ["and","or"]))
                     }
-                    
-                case .timeInterval:
-                    let value: Any = {
-                        if sequenceType == nil {
-                            return 120.0
-                        } else {
-                            switch sequenceType! {
-                            case .array:
-                                return [123.45, 345.67]
-                            case .dictionary:
-                                return ["timestamp": 0.123]
-                            }
-                        }
-                    }()
-                    examples.append((RSDAnswerResultType(baseType: baseType, sequenceType: sequenceType), value))
                 }
             }
         }

--- a/ResearchSuite/ResearchSuite/RSDChoiceOptionsObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDChoiceOptionsObject.swift
@@ -42,10 +42,14 @@ public struct RSDChoiceOptionsObject : RSDChoiceOptions {
     /// A Boolean value indicating whether the user can skip the input field without providing an answer.
     public let isOptional: Bool
     
+    /// The default answer associated with this option set.
+    public let defaultAnswer: Any?
+    
     /// Default initializer. Auto-synthesized init is not public.
-    public init(choices: [RSDChoice], isOptional: Bool) {
+    public init(choices: [RSDChoice], isOptional: Bool, defaultAnswer: Any? = nil) {
         self.choices = choices
         self.isOptional = isOptional
+        self.defaultAnswer = defaultAnswer
     }
 }
 

--- a/ResearchSuite/ResearchSuite/RSDChoicePickerTableItemGroup.swift
+++ b/ResearchSuite/ResearchSuite/RSDChoicePickerTableItemGroup.swift
@@ -129,7 +129,7 @@ open class RSDChoicePickerTableItemGroup : RSDInputFieldTableItemGroup {
 }
 
 /// An item group for entering a boolean data type.
-final class RSDBooleanTableItemGroup : RSDChoicePickerTableItemGroup {
+public final class RSDBooleanTableItemGroup : RSDChoicePickerTableItemGroup {
     
     /// Default initializer.
     /// - parameters:

--- a/ResearchSuite/ResearchSuite/RSDDatePickerDataSourceObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDDatePickerDataSourceObject.swift
@@ -73,48 +73,6 @@ extension RSDDatePickerDataSource {
     }
 }
 
-extension NSCalendar.Unit {
-    
-    /// Convenience initializer for converting from a `Calendar.Component` set to an `NSCalendar.Unit`
-    public init(calendarComponents: Set<Calendar.Component>) {
-        self = calendarComponents.reduce(NSCalendar.Unit(rawValue: 0), { (input, component) -> NSCalendar.Unit in
-            switch component {
-            case .era:
-                return input.union(.era)
-            case .year:
-                return input.union(.year)
-            case .month:
-                return input.union(.month)
-            case .day:
-                return input.union(.day)
-            case .hour:
-                return input.union(.hour)
-            case .minute:
-                return input.union(.minute)
-            case .second:
-                return input.union(.second)
-            case .nanosecond:
-                return input.union(.nanosecond)
-            case .weekday:
-                return input.union(.weekday)
-            case .weekdayOrdinal:
-                return input.union(.weekdayOrdinal)
-            case .quarter:
-                return input.union(.quarter)
-            case .weekOfMonth:
-                return input.union(.weekOfMonth)
-            case .weekOfYear:
-                return input.union(.weekOfYear)
-            case .yearForWeekOfYear:
-                return input.union(.yearForWeekOfYear)
-            case .timeZone:
-                return input.union(.timeZone)
-            case .calendar:
-                return input.union(.calendar)
-            }
-        })
-    }
-}
 
 /// Extension of `RSDDateRange` for setting up calendar components and a data source.
 extension RSDDateRange {

--- a/ResearchSuite/ResearchSuite/RSDDateRangeObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDDateRangeObject.swift
@@ -85,6 +85,35 @@ public struct RSDDateRangeObject : RSDDateRange, Codable {
     
     /// Initialize from a `Decoder`.
     ///
+    /// - example:
+    ///
+    /// Example where the minimum and maximum dates are set to specific values.
+    /// ```
+    ///    {
+    ///     "minimumDate" : "2017-02-20",
+    ///     "maximumDate" : "2017-03-20",
+    ///     "codingFormat" : "yyyy-MM-dd"
+    ///    }
+    /// ```
+    ///
+    /// Example where the range does not allow future dates.
+    /// ```
+    ///     { "allowFuture" : "false" }
+    /// ```
+    ///
+    /// Example where the range does not allow future dates.
+    /// ```
+    ///     { "allowPast" : "false" }
+    /// ```
+    ///
+    /// Example where the time should include hours and minutes, but the minute interval is set to 15 minutes.
+    /// ```
+    ///     {
+    ///      "minuteInterval" : 15,
+    ///      "codingFormat" : "HH:mm"
+    ///     }
+    /// ```
+    ///
     /// - parameter decoder: The decoder to use to decode this instance.
     /// - throws: `DecodingError`
     public init(from decoder: Decoder) throws {

--- a/ResearchSuite/ResearchSuite/RSDDateRangeObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDDateRangeObject.swift
@@ -1,8 +1,8 @@
 //
-//  RSDRangeObject.swift
+//  RSDDateRangeObject.swift
 //  ResearchSuite
 //
-//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//  Copyright © 2017-2018 Sage Bionetworks. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -83,7 +83,7 @@ public struct RSDDateRangeObject : RSDDateRange, Codable {
         case minDate = "minimumDate", maxDate = "maximumDate", allowFuture, allowPast, minuteInterval, codingFormat
     }
     
-    /// Initialize from a `Decoder`. 
+    /// Initialize from a `Decoder`.
     ///
     /// - parameter decoder: The decoder to use to decode this instance.
     /// - throws: `DecodingError`
@@ -106,7 +106,7 @@ public struct RSDDateRangeObject : RSDDateRange, Codable {
             minDate = try container.decodeIfPresent(Date.self, forKey: .minDate)
             maxDate = try container.decodeIfPresent(Date.self, forKey: .maxDate)
         }
-
+        
         self.dateCoder = dateCoder
         self.minDate = minDate
         self.maxDate = maxDate
@@ -184,173 +184,5 @@ extension RSDDateRangeObject : RSDDocumentableCodableObject {
     
     static func examples() -> [Encodable] {
         return dateRangeExamples()
-    }
-}
-
-/// `RSDNumberRangeObject` extends the properties of an `RSDInputField` for a `decimal` or `integer` data type.
-public struct RSDNumberRangeObject : RSDNumberRange, Codable {
-    
-    /// The minimum allowed number. When the value of this property is `nil`, there is no minimum.
-    public let minimumValue: Decimal?
-    
-    /// The maximum allowed number. When the value of this property is `nil`, there is no maximum.
-    public let maximumValue: Decimal?
-    
-    /// A step interval to be used for a slider or picker.
-    public let stepInterval: Decimal?
-    
-    /// A unit label associated with this property. The unit should *not* be localized. Instead, this
-    /// value is used to determine the unit for measurements converted to the unit expected by the researcher.
-    ///
-    /// For example, if a measurement of distance is displayed and/or returned by the user in feet, but the
-    /// researcher expects the returned value in meters then the unit here would be "m" and the formatter
-    /// would be a `LengthFormatter` that uses the current locale with a `unitStyle` of `.long`.
-    public let unit: String?
-    
-    /// `Formatter` that is appropriate to the data type. If `nil`, the format will be determined by the UI.
-    /// This is the formatter used to display a previously entered answer to the user or to convert an answer
-    /// entered in a text field into the appropriate value type.
-    ///
-    /// - note: Currently, the `Codable` protocol only supports instantiating a `NumberFormatter` with a
-    ///         "maximumDigits" key that contains the number of decimal places to display.
-    public let formatter: Formatter?
-    
-    /// Default initializer for a `Decimal` range. This is used to initialize the range for a `Decimal` type.
-    ///
-    /// - parameters:
-    ///     - minimumDecimal: The minimum allowed number.
-    ///     - maximumDecimal: The maximum allowed number.
-    ///     - stepInterval: A step interval to be used for a slider or picker.  Default = `nil`.
-    ///     - unit: A unit label associated with this property.  Default = `nil`.
-    ///     - formatter: `NumberFormatter` that is appropriate to the data type. Default = `nil`.
-    public init(minimumDecimal: Decimal?, maximumDecimal: Decimal?, stepInterval: Decimal? = nil, unit: String? = nil, formatter: Formatter? = nil) {
-        self.minimumValue = minimumDecimal
-        self.maximumValue = maximumDecimal
-        self.stepInterval = stepInterval
-        self.unit = unit
-        self.formatter = formatter
-    }
-    
-    /// Default initializer for an `Int` range. This is used to initialize the range for an `Int` type.
-    ///
-    /// - parameters:
-    ///     - minimumInt: The minimum allowed number.
-    ///     - maximumInt: The maximum allowed number.
-    ///     - stepInterval: A step interval to be used for a slider or picker.  Default = `nil`.
-    ///     - unit: A unit label associated with this property.  Default = `nil`.
-    ///     - formatter: `NumberFormatter` that is appropriate to the data type. Default = `nil`.
-    public init(minimumInt: Int?, maximumInt: Int?, stepInterval: Int? = nil, unit: String? = nil, formatter: Formatter? = nil) {
-        self.minimumValue = (minimumInt == nil) ? nil : Decimal(integerLiteral: minimumInt!)
-        self.maximumValue = (maximumInt == nil) ? nil : Decimal(integerLiteral: maximumInt!)
-        self.stepInterval = (stepInterval == nil) ? nil : Decimal(integerLiteral: stepInterval!)
-        self.unit = unit
-        self.formatter = formatter
-    }
-
-    /// Default initializer for an `Double` range. This is used to initialize the range for a `Double` type.
-    ///
-    /// - parameters:
-    ///     - minimumDouble: The minimum allowed number.
-    ///     - maximumDouble: The maximum allowed number.
-    ///     - stepInterval: A step interval to be used for a slider or picker.  Default = `nil`.
-    ///     - unit: A unit label associated with this property.  Default = `nil`.
-    ///     - formatter: `NumberFormatter` that is appropriate to the data type. Default = `nil`.
-    public init(minimumDouble: Double?, maximumDouble: Double?, stepInterval: Double? = nil, unit: String? = nil, formatter: Formatter? = nil) {
-        self.minimumValue = (minimumDouble == nil) ? nil : Decimal(floatLiteral: minimumDouble!)
-        self.maximumValue = (maximumDouble == nil) ? nil : Decimal(floatLiteral: maximumDouble!)
-        self.stepInterval = (stepInterval == nil) ? nil : Decimal(floatLiteral: stepInterval!)
-        self.unit = unit
-        self.formatter = formatter
-    }
-    
-    private enum CodingKeys : String, CodingKey {
-        case minimumValue, maximumValue, stepInterval, unit, formatter
-    }
-    
-    /// Initialize from a `Decoder`.
-    ///
-    /// - parameter decoder: The decoder to use to decode this instance.
-    /// - throws: `DecodingError`
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let minimumDouble = try container.decodeIfPresent(Double.self, forKey: .minimumValue)
-        let maximumDouble = try container.decodeIfPresent(Double.self, forKey: .maximumValue)
-        let stepInterval = try container.decodeIfPresent(Double.self, forKey: .stepInterval)
-        self.minimumValue = (minimumDouble == nil) ? nil : Decimal(floatLiteral: minimumDouble!)
-        self.maximumValue = (maximumDouble == nil) ? nil : Decimal(floatLiteral: maximumDouble!)
-        self.stepInterval = (stepInterval == nil) ? nil : Decimal(floatLiteral: stepInterval!)
-        self.unit = try container.decodeIfPresent(String.self, forKey: .unit)
-        if container.contains(.formatter) {
-            let nestedDecoder = try container.superDecoder(forKey: .formatter)
-            self.formatter = try decoder.factory.decodeNumberFormatter(from: nestedDecoder)
-        } else {
-            self.formatter = nil
-        }
-    }
-    
-    /// Encode the object to the given encoder.
-    /// - parameter encoder: The encoder to use to encode this instance.
-    /// - throws: `EncodingError`
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        if let obj = (self.minimumValue as NSDecimalNumber?)?.doubleValue {
-            try container.encode(obj, forKey: .minimumValue)
-        }
-        if let obj = (self.maximumValue as NSDecimalNumber?)?.doubleValue {
-            try container.encode(obj, forKey: .maximumValue)
-        }
-        if let obj = (self.stepInterval as NSDecimalNumber?)?.doubleValue  {
-            try container.encode(obj, forKey: .stepInterval)
-        }
-        try container.encodeIfPresent(self.unit, forKey: .unit)
-        
-        if let obj = self.formatter {
-            let nestedEncoder = container.superEncoder(forKey: .formatter)
-            guard let encodable = obj as? Encodable else {
-                throw EncodingError.invalidValue(obj, EncodingError.Context(codingPath: nestedEncoder.codingPath, debugDescription: "The object does not conform to the Encodable protocol"))
-            }
-            try encodable.encode(to: nestedEncoder)
-        }
-    }
-}
-
-extension RSDNumberRangeObject : RSDDocumentableCodableObject {
-    
-    static func codingKeys() -> [CodingKey] {
-        return allCodingKeys()
-    }
-    
-    private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.minimumValue, .maximumValue, .stepInterval, .unit, .formatter]
-        return codingKeys
-    }
-    
-    static func validateAllKeysIncluded() -> Bool {
-        let keys: [CodingKeys] = allCodingKeys()
-        for (idx, key) in keys.enumerated() {
-            switch key {
-            case .minimumValue:
-                if idx != 0 { return false }
-            case .maximumValue:
-                if idx != 1 { return false }
-            case .stepInterval:
-                if idx != 2 { return false }
-            case .unit:
-                if idx != 3 { return false }
-            case .formatter:
-                if idx != 4 { return false }
-            }
-        }
-        return keys.count == 5
-    }
-    
-    static func numberRangeExamples() -> [RSDNumberRangeObject] {
-        let exampleA = RSDNumberRangeObject(minimumDouble: 1.23, maximumDouble: 567.89, stepInterval: 0.01, unit: "m", formatter: NumberFormatter.defaultNumberFormatter(with: 2))
-        let exampleB = RSDNumberRangeObject(minimumInt: -5, maximumInt: 10)
-        return [exampleA, exampleB]
-    }
-    
-    static func examples() -> [Encodable] {
-        return numberRangeExamples()
     }
 }

--- a/ResearchSuite/ResearchSuite/RSDDateRangeObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDDateRangeObject.swift
@@ -45,11 +45,11 @@ public struct RSDDateRangeObject : RSDDateRange, Codable {
     /// property is checked for `nil`, otherwise `allowFuture` is ignored.
     public let maxDate: Date?
     
-    /// Whether or not the UI should allow future dates. If `nil` or if `minDate` is defined then this value
+    /// Whether or not the UI should allow future dates. If `nil` or if `maxDate` is defined then this value
     /// is ignored. Default is `true`.
     public let allowFuture: Bool?
     
-    /// Whether or not the UI should allow past dates. If `nil` or if `maxDate` is defined then this value
+    /// Whether or not the UI should allow past dates. If `nil` or if `minDate` is defined then this value
     /// is ignored. Default is `true`.
     public let allowPast: Bool?
     

--- a/ResearchSuite/ResearchSuite/RSDDeviceType.swift
+++ b/ResearchSuite/ResearchSuite/RSDDeviceType.swift
@@ -61,17 +61,16 @@ public struct RSDDeviceType : RawRepresentable, Codable {
     
     /// A watch is a device that is worn on a person's wrist. (Apple Watch)
     public static let watch: RSDDeviceType = "watch"
-    
+}
+
+extension RSDDeviceType : RSDEnumSet {
     /// List of all the standard types.
-    public static func allStandardTypes() -> [RSDDeviceType] {
+    public static var all: Set<RSDDeviceType> {
         return [.computer, .phone, .tablet, .tv, .watch]
     }
 }
 
 extension RSDDeviceType : RSDDocumentableEnum {
-    static func allCodingKeys() -> [String] {
-        return allStandardTypes().map{ $0.rawValue }
-    }
 }
 
 extension RSDDeviceType : Equatable {

--- a/ResearchSuite/ResearchSuite/RSDDocumentable.swift
+++ b/ResearchSuite/ResearchSuite/RSDDocumentable.swift
@@ -33,6 +33,13 @@
 
 import Foundation
 
+/// `RSDEnumSet` is a protocol for defining the set of all values included in an enum.
+public protocol RSDEnumSet : Hashable, RawRepresentable where RawValue == String {
+    
+    /// The set that includes all the enum values.
+    static var all: Set<Self> { get }
+}
+
 public struct RSDDocumentCreator {
     
     let allEnums: [RSDDocumentableEnum.Type] = [
@@ -82,6 +89,7 @@ public struct RSDDocumentCreator {
         RSDDateRangeObject.self,
         RSDNumberRangeObject.self,
         RSDTextFieldOptionsObject.self,
+        RSDDurationRangeObject.self,
         ]
     
     let allDecodableObjects: [RSDDocumentableDecodableObject.Type] = [
@@ -123,6 +131,13 @@ protocol RSDDocumentableEnum : RSDDocumentable, Codable {
 
     /// All the coding keys supported by this framework for defining this enum using a JSON dictionary.
     static func allCodingKeys() -> [String]
+}
+
+/// Any enum set can represent its coding keys by mapping the raw value to a string.
+extension RSDEnumSet {
+    static func allCodingKeys() -> [String] {
+        return self.all.map{ $0.rawValue }
+    }
 }
 
 /// This is an internal protocol (accessible by test but not externally) that can be used to set up

--- a/ResearchSuite/ResearchSuite/RSDDurationFormatter.h
+++ b/ResearchSuite/ResearchSuite/RSDDurationFormatter.h
@@ -1,8 +1,8 @@
 //
-//  NSUnit+RSDUnitConversion.h
+//  RSDDurationFormatter.h
 //  ResearchSuite
 //
-//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//  Copyright © 2018 Sage Bionetworks. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -35,35 +35,37 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface NSUnit (RSDUnitConversion)
+/// `RSDDurationFormatter` is a custom subclass of the `NSDateComponentsFormatter` that can convert a
+/// `NSMeasurement` object to a localized string.
+///
+/// - note: While this SDK is written in Swift where permissibile, formatters are written in Obj-c to allow
+/// overriding `-getObjectValue:forString:errorDescription:`. Apple documentation does not include how to
+/// set the value of the pointer for a Swift 4 implementation of the function. syoung 12/30/2017
+///
+@interface RSDDurationFormatter : NSDateComponentsFormatter
 
-/// Convert the symbol into a unit of the appropriate subtype (if found).
-/// @param symbol   The symbol for the unit.
-+ (NSUnit * _Nullable)unitFromSymbol:(NSString *)symbol;
+/// The base unit to use for converting a `NSNumber` to a string.
+///
+/// This is used by the `-stringForObjectValue:` method to convert the input object to a localized string
+/// for the case where the object value is a `NSNumber`. If the input object is a `NSMeasurement` then
+/// this value is ignored.
+///
+/// The default unit is seconds.
+@property (null_resettable, nonatomic) NSUnitDuration *toStringUnit;
 
-@end
+/// The base unit to use for converting a string to an `NSMeasurement`.
+///
+/// This is used by the `-getObjectValue:forString:errorDescription:` method to convert the input string
+/// to a `NSMeasurement` if the units cannot be parsed from the input string.
+///
+/// The default unit is seconds.
+@property (null_resettable, nonatomic) NSUnitDuration *fromStringUnit;
 
-@interface NSUnitLength (RSDUnitConversion)
+/// Return the number value (or nil) for the given string.
+- (NSNumber * _Nullable)numberFromString:(NSString *)string;
 
-/// Convert the symbol into a unit of length.
-/// @param symbol   The symbol for the unit.
-+ (NSUnitLength * _Nullable)unitLengthFromSymbol:(NSString *)symbol;
-
-@end
-
-@interface NSUnitMass (RSDUnitConversion)
-
-/// Convert the symbol into a unit of mass.
-/// @param symbol   The symbol for the unit.
-+ (NSUnitMass * _Nullable)unitMassFromSymbol:(NSString *)symbol;
-
-@end
-
-@interface NSUnitDuration (RSDUnitConversion)
-
-/// Convert the symbol into a unit of duration.
-/// @param symbol   The symbol for the unit.
-+ (NSUnitDuration * _Nullable)unitDurationFromSymbol:(NSString *)symbol;
+/// Return the string (or nil) for the given number.
+- (NSString * _Nullable)stringFromNumber:(NSNumber *)number;
 
 @end
 

--- a/ResearchSuite/ResearchSuite/RSDDurationFormatter.m
+++ b/ResearchSuite/ResearchSuite/RSDDurationFormatter.m
@@ -1,0 +1,249 @@
+//
+//  RSDDurationFormatter.m
+//  ResearchSuite
+//
+//  Copyright © 2018 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#import "RSDDurationFormatter.h"
+#import "NSUnit+RSDUnitConversion.h"
+#import "RSDMeasurementWrapper.h"
+
+@interface RSDDurationFormatter () <RSDMeasurementFormatter>
+@property (null_resettable, nonatomic) NSNumberFormatter *numberFormatter;
+@end
+
+@implementation RSDDurationFormatter
+
+- (NSNumberFormatter *)numberFormatter {
+    if (_numberFormatter == nil) {
+        _numberFormatter = [[NSNumberFormatter alloc] init];
+        _numberFormatter.locale = [self locale];
+    }
+    return _numberFormatter;
+}
+
+- (NSUnitDuration *)toStringUnit {
+    return _toStringUnit ? : [self defaultUnit];
+}
+
+- (NSUnitDuration *)fromStringUnit {
+    return _fromStringUnit ? : [self defaultUnit];
+}
+
+- (NSUnitDuration *)defaultUnit {
+    return NSUnitDuration.seconds;
+}
+
+- (NSLocale *)locale {
+    return self.calendar.locale ? : NSLocale.currentLocale;
+}
+
+- (NSNumber * _Nullable)numberFromString:(NSString *)string {
+    id obj;
+    if ([self getObjectValue:&obj forString:string errorDescription:nil]) {
+        if ([obj isKindOfClass:[NSNumber class]]) {
+            return (NSNumber *)[obj copy];
+        } else if ([obj isKindOfClass:[NSMeasurement class]]) {
+            return @([[(NSMeasurement *)obj measurementByConvertingToUnit:self.fromStringUnit] doubleValue]);
+        }
+    }
+    return nil;
+}
+
+/// Return the string (or nil) for the given number.
+- (NSString * _Nullable)stringFromNumber:(NSNumber *)number {
+    return [self stringForObjectValue: number];
+}
+
+- (NSString *)stringForObjectValue:(id)obj {
+    if (obj == nil) { return nil; }
+    
+    if ([obj isKindOfClass:[NSDateComponents class]]) {
+        return [super stringForObjectValue:obj];
+    }
+    
+    // convert the object to a measurement
+    NSMeasurement *measurement = nil;
+    if ([obj isKindOfClass:[NSMeasurement class]]) {
+        measurement = (NSMeasurement *)obj;
+    } else if ([obj isKindOfClass:[NSNumber class]]) {
+        double num = [(NSNumber *)obj doubleValue];
+        measurement = [[NSMeasurement alloc] initWithDoubleValue:num unit:self.toStringUnit];
+    } else if ([obj isKindOfClass:[NSString class]]) {
+        double num = [(NSString *)obj doubleValue];
+        measurement = [[NSMeasurement alloc] initWithDoubleValue:num unit:self.toStringUnit];
+    } else {
+        return [super stringForObjectValue:obj];
+    }
+    
+    NSTimeInterval ti = [[measurement measurementByConvertingToUnit: NSUnitDuration.seconds] doubleValue];
+    return [self stringFromTimeInterval:ti];
+}
+
+- (BOOL)getObjectValue:(out id  _Nullable __autoreleasing *)obj forString:(NSString *)string errorDescription:(out NSString *__autoreleasing  _Nullable *)error {
+    
+    // A zero-length string cannot be converted.
+    if (string.length == 0) { return false; }
+    
+    // syoung 12/29/2017 As of this writing, any input value will return nil. If this formatter
+    // implements conversion at some future point, defer to that as being more likely to have a
+    // localized value than this version (which is only tested against US English).
+    id superObj;
+    if ([super getObjectValue:&superObj forString:string errorDescription:nil]) {
+        if ([superObj isKindOfClass:[NSNumber class]]) {
+            NSNumber *num = (NSNumber *)superObj;
+            NSMeasurement *measurement = [[NSMeasurement alloc] initWithDoubleValue:num.doubleValue unit:NSUnitLength.meters];
+            *obj = measurement;
+            return true;
+        } else if ([superObj isKindOfClass:[NSMeasurement class]]) {
+            *obj = superObj;
+            return true;
+        }
+    }
+    
+    __block NSMeasurement *measurement = nil;
+    
+    // Check to see if the string can be separated into components using positional formatting.
+    // Note: This is only tested for US English. syoung 02/01/2018
+    NSArray *components = [string componentsSeparatedByString:@":"];
+    if (components.count > 1) {
+        NSMutableArray <NSUnitDuration *> * allowedUnits = [NSMutableArray new];
+        if ((self.allowedUnits & NSCalendarUnitHour) != 0) {
+            [allowedUnits addObject: NSUnitDuration.hours];
+        }
+        if ((self.allowedUnits & NSCalendarUnitMinute) != 0) {
+            [allowedUnits addObject: NSUnitDuration.minutes];
+        }
+        if ((self.allowedUnits & NSCalendarUnitSecond) != 0) {
+            [allowedUnits addObject: NSUnitDuration.seconds];
+        }
+        measurement = [[NSMeasurement alloc] initWithDoubleValue:0 unit:self.fromStringUnit];
+        [allowedUnits enumerateObjectsUsingBlock:^(NSUnitDuration * _Nonnull unit, NSUInteger idx, BOOL * _Nonnull stop) {
+            if (idx < components.count) {
+                NSString *numberString = components[idx];
+                NSNumber *number = [self.numberFormatter numberFromString:numberString];
+                if (number) {
+                    NSMeasurement *part = [[NSMeasurement alloc] initWithDoubleValue:[number doubleValue] unit:unit];
+                    measurement = [measurement measurementByAddingMeasurement:part] ? : part;
+                }
+            }
+        }];
+    } else {
+        // If not a positional string separated by components then use the measurement wrapper.
+        measurement = [RSDMeasurementWrapper measurementFromString:string withFormatter:self];
+    }
+    
+    if (measurement) {
+        *obj = measurement;
+    }
+    return (measurement != nil);
+}
+
+- (NSMeasurement *)measurementForNumber:(NSNumber *)number unit:(NSString *)unitString {
+    NSUnitDuration *unit = [self unitForString:unitString] ? : self.fromStringUnit;
+    double measurementValue = [number doubleValue];
+    return [[NSMeasurement alloc] initWithDoubleValue:measurementValue unit:unit];
+}
+
+- (NSUnitDuration *)unitForString:(NSString *)string {
+    NSString *trimmedString = [string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (trimmedString.length == 0) {
+        return nil;
+    } else {
+        return [NSUnitDuration unitDurationFromSymbol: trimmedString] ? : [self unitForLocalizedString: trimmedString];
+    }
+}
+
+- (NSUnitDuration * _Nullable)unitForLocalizedString:(NSString*)string {
+
+    NSArray * units = @[NSUnitDuration.seconds, NSUnitDuration.minutes, NSUnitDuration.hours];
+    
+    NSMeasurementFormatter *formatter = [NSMeasurementFormatter new];
+    formatter.unitOptions = NSMeasurementFormatterUnitOptionsProvidedUnit;
+
+    for (NSUnitDuration *unit in units) {
+        for (NSFormattingUnitStyle unitStyle = NSFormattingUnitStyleShort; unitStyle <= NSFormattingUnitStyleLong; unitStyle++) {
+            formatter.unitStyle = unitStyle;
+            if ([string isEqualToString:[formatter stringFromUnit:unit]]) {
+                return unit;
+            }
+        }
+    }
+    
+    return nil;
+}
+
+
+#pragma mark - Coding, copying, and equality inheritance
+
++ (BOOL)supportsSecureCoding {
+    return true;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        _toStringUnit = [aDecoder decodeObjectOfClass:[NSUnitLength class] forKey:NSStringFromSelector(@selector(toStringUnit))];
+        _fromStringUnit = [aDecoder decodeObjectOfClass:[NSUnitLength class] forKey:NSStringFromSelector(@selector(fromStringUnit))];
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+    [super encodeWithCoder:aCoder];
+    [aCoder encodeObject:_toStringUnit forKey:NSStringFromSelector(@selector(toStringUnit))];
+    [aCoder encodeObject:_fromStringUnit forKey:NSStringFromSelector(@selector(fromStringUnit))];
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    RSDDurationFormatter *copy = [super copyWithZone:zone];
+    copy.toStringUnit = [self.toStringUnit copy];
+    copy.fromStringUnit = [self.fromStringUnit copy];
+    return copy;
+}
+
+- (BOOL)isEqual:(id)other {
+    if (other == self) {
+        return YES;
+    } else if (![super isEqual:other] || ![other isKindOfClass:[self class]]) {
+        return NO;
+    } else {
+        RSDDurationFormatter *castObject = (RSDDurationFormatter *)other;
+        return [other isKindOfClass:[self class]] &&
+        self.toStringUnit == castObject.toStringUnit &&
+        self.fromStringUnit == castObject.fromStringUnit;
+    }
+}
+
+- (NSUInteger)hash {
+    return [super hash] ^ self.toStringUnit.hash ^ self.fromStringUnit.hash;
+}
+
+@end

--- a/ResearchSuite/ResearchSuite/RSDDurationPickerDataSourceObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDDurationPickerDataSourceObject.swift
@@ -55,7 +55,7 @@ public struct RSDDurationPickerDataSourceObject : RSDMultipleComponentChoiceOpti
     /// The formatter for displaying the duration.
     let formatter: DateComponentsFormatter
     
-    /// The separator is not used with the hieght picker.
+    /// The separator is not used with the height picker.
     public let separator: String?
     
     /// The default answer associated with this option set.
@@ -152,7 +152,7 @@ extension RSDDurationRange {
         return self.minimumDuration.unit
     }
     
-    /// Convenience method for getting the date components formatter for this range
+    /// Convenience method for getting the date components formatter for this range.
     public func dateComponentsFormatter() -> DateComponentsFormatter {
         return ((self as? RSDRangeWithFormatter)?.formatter as? DateComponentsFormatter) ?? UnitDuration.defaultFormatter(for: self.durationUnits, baseUnit: self.baseUnit)
     }

--- a/ResearchSuite/ResearchSuite/RSDDurationPickerDataSourceObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDDurationPickerDataSourceObject.swift
@@ -1,0 +1,159 @@
+//
+//  RSDDurationPickerDataSourceObject.swift
+//  ResearchSuite
+//
+//  Copyright © 2018 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+/// `RSDDurationPickerDataSourceObject` is a concrete implementation of a `RSDMultipleComponentChoiceOptions`
+/// that can be used to select a duration using duration units for each component of the duration.
+public struct RSDDurationPickerDataSourceObject : RSDMultipleComponentChoiceOptions {
+    
+    /// A list of choices for the input field.
+    public var choices: [[RSDChoice]] {
+        return componentChoices
+    }
+    
+    /// The unit that the answer should use to represent the selection.
+    let baseUnit: UnitDuration
+    
+    /// The mapping of the unit representing each column in the picker.
+    let componentUnits: [UnitDuration]
+    
+    /// The arrays of Int objects for each column of the duration represented by
+    /// by this picker.
+    let componentChoices: [[RSDChoiceObject<Int>]]
+    
+    /// The formatter for displaying the duration.
+    let formatter: DateComponentsFormatter
+    
+    /// The separator is not used with the hieght picker.
+    public let separator: String?
+    
+    /// The default answer associated with this option set.
+    public let defaultAnswer: Any?
+    
+    /// Default initializer.
+    /// - parameter range: The duration range to use to instantiate this picker source.
+    public init?(range: RSDDurationRange) {
+        guard let maxUnit = range.durationUnits.max(),
+            let minUnit = range.durationUnits.min()
+            else {
+                return nil
+        }
+
+        let componentUnits = range.durationUnits.sorted(by: >)
+        self.componentChoices = componentUnits.map { (unit) -> [RSDChoiceObject<Int>] in
+            
+            let indexBy = (unit == minUnit) ? (range.stepInterval ?? 1) : 1
+            let maxValue: Int = {
+                if (unit == maxUnit) {
+                    return range.maximumDuration?.component(of: unit) ?? unit.maxTimeValue()
+                } else {
+                    return unit.maxTimeValue() - indexBy
+                }
+            }()
+            
+            let range = Array(stride(from: 0, to: maxValue + indexBy, by: indexBy))
+            return range.map { try! RSDChoiceObject<Int>(value: $0, text: String(format: "%02d", $0)) }
+        }
+        
+        let dateComponentsFormatter = range.dateComponentsFormatter()
+        
+        self.componentUnits = componentUnits
+        self.formatter = dateComponentsFormatter
+        self.baseUnit = range.baseUnit
+        self.separator = (dateComponentsFormatter.unitsStyle == .positional) ? ":" : nil
+        self.defaultAnswer = range.minimumDuration.value
+    }
+    
+    /// Returns the selected answer created by the union of the selected rows.
+    /// - parameter selectedRows: The selected rows, where there is a selected row for each component.
+    /// - returns: The answer created from the given array of selected rows.
+    public func selectedAnswer(with selectedRows: [Int]) -> Any? {
+        let value: Double = selectedRows.enumerated().reduce(0) { (input, arg) -> Double in
+            let (component, index) = arg
+            let unit = self.componentUnits[component]
+            let choiceValue = self.componentChoices[component][index].value as! Int
+            let measurement = Measurement(value: Double(choiceValue), unit: unit)
+            return input + measurement.valueConverted(to: baseUnit)
+        }
+        return value
+    }
+    
+    /// Returns the selected rows that match the given selected answer (if any).
+    /// - parameter selectedAnswer: The selected answer.
+    /// - returns: The selected rows, where there is a selected row for each component, or `nil` if not
+    ///            all rows are selected.
+    public func selectedRows(from selectedAnswer: Any?) -> [Int]? {
+        guard let duration = duration(for: selectedAnswer) else { return nil }
+        return componentUnits.enumerated().map { (idx, unit) -> Int in
+            let value = duration.component(of: unit)
+            return self.componentChoices[idx].index(where: { ($0.value as! Int) == value }) ?? 0
+        }
+    }
+    
+    /// Returns the text answer to display for a given selected answer.
+    /// - parameter selectedAnswer: The answer to convert.
+    /// - returns: A text value for the answer to display to the user.
+    public func textAnswer(from selectedAnswer: Any?) -> String? {
+        guard let duration = duration(for: selectedAnswer) else { return nil }
+        return formatter.string(from: duration.timeInterval)
+    }
+    
+    /// The duration measurement (if any) for the given answer.
+    /// - parameter answer: The object to convert to a duration measurement.
+    /// - returns: The duration measurement (if any).
+    public func duration(for answer: Any?) -> Measurement<UnitDuration>? {
+        if let duration = answer as? Measurement<UnitDuration> {
+            return duration
+        }
+        else if let num = (answer as? RSDJSONNumber)?.jsonNumber() {
+            return Measurement<UnitDuration>(value: num.doubleValue, unit: baseUnit)
+        }
+        else {
+            return nil
+        }
+    }
+}
+
+extension RSDDurationRange {
+    
+    /// Convenience method for getting the base unit associated with this range.
+    public var baseUnit: UnitDuration {
+        return self.minimumDuration.unit
+    }
+    
+    /// Convenience method for getting the date components formatter for this range
+    public func dateComponentsFormatter() -> DateComponentsFormatter {
+        return ((self as? RSDRangeWithFormatter)?.formatter as? DateComponentsFormatter) ?? UnitDuration.defaultFormatter(for: self.durationUnits, baseUnit: self.baseUnit)
+    }
+}

--- a/ResearchSuite/ResearchSuite/RSDDurationRangeObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDDurationRangeObject.swift
@@ -33,7 +33,7 @@
 
 import Foundation
 
-/// `RSDDurationRangeObject` extends the properties of an `RSDInputField` for a `timeInterval` data type.
+/// `RSDDurationRangeObject` extends the properties of an `RSDInputField` for a `.duration` data type.
 public struct RSDDurationRangeObject : RSDDurationRange, RSDRangeWithFormatter, Codable {
     
     /// The minimum allowed duration.
@@ -46,7 +46,7 @@ public struct RSDDurationRangeObject : RSDDurationRange, RSDRangeWithFormatter, 
     public let stepInterval: Int?
     
     /// The duration units that should be included in the formatter and picker used for setting up a
-    /// `.timeInterval` data type.
+    /// `.duration` data type.
     public let durationUnits: Set<UnitDuration>
     
     /// `Formatter` that is appropriate to the data type. For a duration, the formatter is a
@@ -56,8 +56,9 @@ public struct RSDDurationRangeObject : RSDDurationRange, RSDRangeWithFormatter, 
     /// Default initializer for a `Decimal` range. This is used to initialize the range for a `Decimal` type.
     ///
     /// - parameters:
-    ///     - durationUnits: The units that should be included in the formatter and picker.
-    ///     - minimumDuration: The minimum allowed duration.
+    ///     - durationUnits: The units that should be included in the formatter and picker. If `nil` then the
+    ///                      the default will include all units.
+    ///     - minimumDuration: The minimum allowed duration. If `nil` then the default will be `0`.
     ///     - maximumDuration: The maximum allowed duration.
     ///     - stepInterval: A step interval to be used for a slider or picker in the smallest units represented.
     public init(durationUnits: Set<UnitDuration>? = nil, minimumDuration: Measurement<UnitDuration>? = nil, maximumDuration: Measurement<UnitDuration>? = nil, stepInterval: Int? = nil) {
@@ -80,6 +81,17 @@ public struct RSDDurationRangeObject : RSDDurationRange, RSDRangeWithFormatter, 
     }
     
     /// Initialize from a `Decoder`.
+    ///
+    /// - example:
+    ///
+    /// ```
+    ///     { "minimumValue" : 15,
+    ///       "maximumValue" : 360,
+    ///       "stepInterval" : 5,
+    ///       "unit" : "min",
+    ///       "durationUnits" : ["min", "hr"]
+    ///    }
+    /// ```
     ///
     /// - parameter decoder: The decoder to use to decode this instance.
     /// - throws: `DecodingError`

--- a/ResearchSuite/ResearchSuite/RSDDurationRangeObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDDurationRangeObject.swift
@@ -1,0 +1,354 @@
+//
+//  RSDRangeObject.swift
+//  ResearchSuite
+//
+//  Copyright © 2018 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+/// `RSDDurationRangeObject` extends the properties of an `RSDInputField` for a `timeInterval` data type.
+public struct RSDDurationRangeObject : RSDDurationRange, RSDRangeWithFormatter, Codable {
+    
+    /// The minimum allowed duration.
+    public let minimumDuration: Measurement<UnitDuration>
+    
+    /// The maximum allowed duration. When the value of this property is `nil`, there is no maximum.
+    public let maximumDuration: Measurement<UnitDuration>?
+    
+    /// A step interval to be used for a slider or picker in the smallest units represented.
+    public let stepInterval: Int?
+    
+    /// The duration units that should be included in the formatter and picker used for setting up a
+    /// `.timeInterval` data type.
+    public let durationUnits: Set<UnitDuration>
+    
+    /// `Formatter` that is appropriate to the data type. For a duration, the formatter is a
+    /// `DateComponentsFormatter`.
+    public var formatter: Formatter?
+    
+    /// Default initializer for a `Decimal` range. This is used to initialize the range for a `Decimal` type.
+    ///
+    /// - parameters:
+    ///     - durationUnits: The units that should be included in the formatter and picker.
+    ///     - minimumDuration: The minimum allowed duration.
+    ///     - maximumDuration: The maximum allowed duration.
+    ///     - stepInterval: A step interval to be used for a slider or picker in the smallest units represented.
+    public init(durationUnits: Set<UnitDuration>? = nil, minimumDuration: Measurement<UnitDuration>? = nil, maximumDuration: Measurement<UnitDuration>? = nil, stepInterval: Int? = nil) {
+        
+        // Get the defaults
+        let baseUnit = durationUnits?.min() ?? minimumDuration?.unit ?? .seconds
+        let units = durationUnits ?? baseUnit.defaultUnits(with: maximumDuration)
+        let min = minimumDuration?.converted(to: baseUnit) ?? Measurement(value: 0, unit: baseUnit)
+
+        // Set the units
+        self.durationUnits = units
+        self.minimumDuration = min
+        self.maximumDuration = maximumDuration
+        self.stepInterval = stepInterval
+        self.formatter = UnitDuration.defaultFormatter(for: units, baseUnit: baseUnit)
+    }
+
+    private enum CodingKeys : String, CodingKey {
+        case minimumValue, maximumValue, stepInterval, unit, durationUnits
+    }
+    
+    /// Initialize from a `Decoder`.
+    ///
+    /// - parameter decoder: The decoder to use to decode this instance.
+    /// - throws: `DecodingError`
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let unitSymbols = try container.decodeIfPresent(Set<String>.self, forKey: .durationUnits)
+        let durationUnits = unitSymbols?.rsd_mapAndFilterSet { UnitDuration(fromSymbol: $0)}
+        
+        let baseUnitSymbol = try container.decodeIfPresent(String.self, forKey: .unit)
+        let baseUnit = durationUnits?.min() ?? baseUnitSymbol?.unitDuration() ?? .seconds
+ 
+        let minimumValue = try container.decodeIfPresent(Double.self, forKey: .minimumValue) ?? 0
+        self.minimumDuration = Measurement(value: minimumValue, unit: baseUnit)
+        self.maximumDuration = try {
+            guard let maximum = try container.decodeIfPresent(Double.self, forKey: .maximumValue) else { return nil }
+            return Measurement(value: maximum, unit: baseUnit)
+        }()
+        
+        self.stepInterval = try container.decodeIfPresent(Int.self, forKey: .stepInterval)
+        
+        let units = durationUnits ?? baseUnit.defaultUnits()
+        self.durationUnits = units
+        self.formatter = UnitDuration.defaultFormatter(for: units, baseUnit: baseUnit)
+    }
+    
+    /// Encode the object to the given encoder.
+    /// - parameter encoder: The encoder to use to encode this instance.
+    /// - throws: `EncodingError`
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.minimumDuration.value, forKey: .minimumValue)
+        try container.encodeIfPresent(self.maximumDuration?.converted(to: baseUnit).value, forKey: .maximumValue)
+        try container.encodeIfPresent(self.stepInterval, forKey: .stepInterval)
+        try container.encode(self.baseUnit.symbol, forKey: .unit)
+        try container.encode(self.durationUnits.map { $0.symbol }, forKey: .durationUnits)
+    }
+}
+
+extension String {
+    fileprivate func unitDuration() -> UnitDuration? {
+        return UnitDuration(fromSymbol: self)
+    }
+}
+
+extension Double {
+    fileprivate func measurement(with unit: Unit) -> Measurement<Unit> {
+        return Measurement(value: self, unit: unit)
+    }
+}
+
+extension UnitDuration {
+    
+    /// Returns a date components formatter set up for displaying duration values.
+    /// - parameter units: The units of the formatter.
+    /// - returns: A date components formatter set up to display a duration.
+    public static func defaultFormatter(for units: Set<UnitDuration>, baseUnit: UnitDuration? = nil) -> RSDDurationFormatter {
+        // set the default formatter
+        let formatter = RSDDurationFormatter()
+        formatter.unitsStyle = .positional
+        formatter.zeroFormattingBehavior = .pad
+        formatter.allowedUnits = NSCalendar.Unit(durationUnits: units)
+        formatter.fromStringUnit = baseUnit ?? units.min()
+        formatter.toStringUnit = baseUnit ?? units.max()
+        return formatter
+    }
+
+    /// The calendar component that maps to this unit.
+    public var calendarComponent: Calendar.Component {
+        switch self {
+        case .hours:
+            return .hour
+        case .minutes:
+            return .minute
+        default:
+            return .second
+        }
+    }
+}
+
+extension UnitDuration : Comparable {
+    
+    /// The maximum value represented by this unit.
+    public func maxTimeValue() -> Int {
+        switch self {
+        case .hours:
+            return 24
+        default:
+            return 60
+        }
+    }
+    
+    /// Calculate the set of units that are a valid subset of the display units used in a
+    /// picker for entering time intervals where `self` is the base unit.
+    ///
+    /// If the `max` duration is `nil`, then this function will return the units that
+    /// are greater than or equal to `self`. Otherwise, the subset will only include those
+    /// units that are less than the max interval. For example, if the maximum interval is
+    /// 30 minutes, then the `.hour` unit is *not* included.
+    ///
+    /// - parameter max: The duration that defines the maximum valid interval.
+    public func defaultUnits(with max: Measurement<UnitDuration>? = nil) -> Set<UnitDuration> {
+        let subset = Set(UnitDuration.all.filter { $0 >= self })
+        guard let maxValue = max
+            else {
+                return subset
+        }
+        if maxValue.hours > 1 {
+            return subset
+        }
+        else if maxValue.minutes > 1 {
+            return subset.intersection([.minutes, .seconds])
+        }
+        else {
+            return subset.intersection([.seconds])
+        }
+    }
+    
+    /// Increment up to the next larger unit.
+    public func increment() -> UnitDuration? {
+        let sizeOrder = UnitDuration.all.sorted(by: <)
+        guard let idx = sizeOrder.index(of: self), idx + 1 < sizeOrder.count else { return nil }
+        return sizeOrder[idx + 1]
+    }
+    
+    /// The set of all the units.
+    public static var all: Set<UnitDuration> {
+        return [.seconds, .minutes, .hours]
+    }
+    
+    /// Compariable implementation.
+    public static func <(lhs: UnitDuration, rhs: UnitDuration) -> Bool {
+        guard let left = lhs.converter as? UnitConverterLinear,
+            let right = rhs.converter as? UnitConverterLinear else { return false }
+        return left.coefficient < right.coefficient
+    }
+}
+
+extension Measurement where UnitType : UnitDuration {
+    
+    /// The hours component of the measurement.
+    public var hours : Int {
+        return self.component(of: .hours)
+    }
+    
+    /// The minutes component of the measurement.
+    public var minutes : Int {
+        return self.component(of: .minutes)
+    }
+    
+    /// The seconds component of the measurement.
+    public var seconds : Int {
+        return self.component(of: .seconds)
+    }
+    
+    /// The duration represented by this measurement.
+    public var timeInterval : TimeInterval {
+        return self.valueConverted(to: .seconds)
+    }
+    
+    /// The value of the measurement in the given units.
+    /// - parameter unit: The unit of duration.
+    /// - returns: The value of the converted measurement.
+    public func valueConverted(to unit: UnitDuration) -> Double {
+        return self.converted(to: unit as! UnitType).value
+    }
+    
+    /// The whole number value of the component part represented by the given
+    /// unit of duration.
+    /// - parameter unit: The unit for which return the component.
+    /// - returns: The whole number value for the given component.
+    public func component(of unit: UnitDuration) -> Int {
+        guard let biggerUnit = unit.increment()
+            else {
+                return Int(floor(self.valueConverted(to: unit)))
+        }
+        let biggerValue = floor(self.valueConverted(to: biggerUnit))
+        let biggerMeasurement = Measurement<UnitDuration>(value: biggerValue, unit: biggerUnit)
+        let diff = self.valueConverted(to: unit) - biggerMeasurement.valueConverted(to: unit)
+        return Int(floor(diff))
+    }
+}
+
+extension NSCalendar.Unit {
+    
+    /// Convenience initializer for converting from a `RSDDurationUnit` set to an `NSCalendar.Unit`
+    public init(durationUnits: Set<UnitDuration>) {
+        let calendarComponents = durationUnits.map { $0.calendarComponent }
+        self.init(calendarComponents: Set(calendarComponents))
+    }
+    
+    /// Convenience initializer for converting from a `Calendar.Component` set to an `NSCalendar.Unit`
+    public init(calendarComponents: Set<Calendar.Component>) {
+        self = calendarComponents.reduce(NSCalendar.Unit(rawValue: 0), { (input, component) -> NSCalendar.Unit in
+            switch component {
+            case .era:
+                return input.union(.era)
+            case .year:
+                return input.union(.year)
+            case .month:
+                return input.union(.month)
+            case .day:
+                return input.union(.day)
+            case .hour:
+                return input.union(.hour)
+            case .minute:
+                return input.union(.minute)
+            case .second:
+                return input.union(.second)
+            case .nanosecond:
+                return input.union(.nanosecond)
+            case .weekday:
+                return input.union(.weekday)
+            case .weekdayOrdinal:
+                return input.union(.weekdayOrdinal)
+            case .quarter:
+                return input.union(.quarter)
+            case .weekOfMonth:
+                return input.union(.weekOfMonth)
+            case .weekOfYear:
+                return input.union(.weekOfYear)
+            case .yearForWeekOfYear:
+                return input.union(.yearForWeekOfYear)
+            case .timeZone:
+                return input.union(.timeZone)
+            case .calendar:
+                return input.union(.calendar)
+            }
+        })
+    }
+}
+
+extension RSDDurationRangeObject : RSDDocumentableCodableObject {
+
+    static func codingKeys() -> [CodingKey] {
+        return allCodingKeys()
+    }
+
+    private static func allCodingKeys() -> [CodingKeys] {
+        let codingKeys: [CodingKeys] = [.minimumValue, .maximumValue, .stepInterval, .unit, .durationUnits]
+        return codingKeys
+    }
+
+    static func validateAllKeysIncluded() -> Bool {
+        let keys: [CodingKeys] = allCodingKeys()
+        for (idx, key) in keys.enumerated() {
+            switch key {
+            case .minimumValue:
+                if idx != 0 { return false }
+            case .maximumValue:
+                if idx != 1 { return false }
+            case .stepInterval:
+                if idx != 2 { return false }
+            case .unit:
+                if idx != 3 { return false }
+            case .durationUnits:
+                if idx != 4 { return false }
+            }
+        }
+        return keys.count == 5
+    }
+
+    static func rangeExamples() -> [RSDDurationRangeObject] {
+        return [RSDDurationRangeObject()]
+    }
+
+    static func examples() -> [Encodable] {
+        return rangeExamples()
+    }
+}
+
+

--- a/ResearchSuite/ResearchSuite/RSDFormDataType.swift
+++ b/ResearchSuite/ResearchSuite/RSDFormDataType.swift
@@ -69,33 +69,31 @@ public enum RSDFormDataType {
         /// type can map to a `RSDDateRange` to box the allowed values.
         case date
         
-        /// In a year question, the participant can enter a year when an event occured. A year data type can map
-        /// to an `RSDDateRange` or `RSDNumberRange` to box the allowed values.
-        case year
-        
         /// The decimal question type asks the participant to enter a decimal number. A decimal data type can
         /// map to a `RSDNumberRange` to box the allowed values.
         case decimal
         
-        /// The integer question type asks the participant to enter an integer number. An integer data type can
-        /// map to a `RSDNumberRange` to box the allowed values, but will store the value as an `Int`.
-        case integer
+        /// In a duration question, the participant can enter a time span such as "8 hours, 5 minutes"
+        /// or "3 minutes, 15 seconds"
+        case duration
         
         /// The fraction question type asks the participant to enter a fractional number. A fractional data type
         /// can map to a `RSDNumberRange` to box the allowed values.
         case fraction
         
+        /// The integer question type asks the participant to enter an integer number. An integer data type can
+        /// map to a `RSDNumberRange` to box the allowed values, but will store the value as an `Int`.
+        case integer
+        
         /// In a string question, the participant can enter text.
         case string
         
-        /// In a time interval question, the participant can enter a time span such as "4 years, 3 months" or
-        /// "8 hours, 5 minutes".
-        // TODO: syoung 10/06/2017 add TimeIntervalRange
-        // https://github.com/ResearchKit/SageResearch/issues/8
-        //case timeInterval
+        /// In a year question, the participant can enter a year when an event occured. A year data type can map
+        /// to an `RSDDateRange` or `RSDNumberRange` to box the allowed values.
+        case year
         
         public static func allTypes() -> [BaseType] {
-            return [.boolean, .date, .decimal, .integer, .fraction, .string, .year]
+            return [.boolean, .date, .decimal, .fraction, .integer, .string, .duration, .year]
         }
     }
     
@@ -155,6 +153,12 @@ public enum RSDFormDataType {
     }
     
     /// List of the standard UI hints that are valid for this data type.
+    ///
+    /// The valid hints are returned in priority order such that if the preferred hint is not
+    /// supported by the UI then a fall-back will be selected. For example, `.base(.date)` will
+    /// return `.picker` as its preferred hint, whereas `.base(.integer)` will return `.textfield`,
+    /// but both support `.textfield` *and* `.picker`.
+    ///
     public var validStandardUIHints: Set<RSDFormUIHint> {
         switch self {
         case .base(let baseType):
@@ -162,7 +166,7 @@ public enum RSDFormDataType {
             case .boolean:
                 return [.list, .picker, .checkbox, .radioButton, .toggle]
                 
-            case .date:
+            case .date, .duration:
                 return [.picker, .textfield]
                 
             case .decimal, .integer, .year, .fraction:
@@ -239,7 +243,7 @@ public enum RSDFormDataType {
             return .boolean
         case .date:
             return .date
-        case .decimal, .fraction:
+        case .decimal, .fraction, .duration:
             return .decimal
         case .integer, .year:
             return .integer

--- a/ResearchSuite/ResearchSuite/RSDFormDataType.swift
+++ b/ResearchSuite/ResearchSuite/RSDFormDataType.swift
@@ -74,7 +74,7 @@ public enum RSDFormDataType {
         case decimal
         
         /// In a duration question, the participant can enter a time span such as "8 hours, 5 minutes"
-        /// or "3 minutes, 15 seconds"
+        /// or "3 minutes, 15 seconds".
         case duration
         
         /// The fraction question type asks the participant to enter a fractional number. A fractional data type

--- a/ResearchSuite/ResearchSuite/RSDFormStepDataSourceObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDFormStepDataSourceObject.swift
@@ -187,7 +187,7 @@ open class RSDFormStepDataSourceObject : RSDFormStepDataSource {
                 return RSDTextFieldTableItemGroup(beginningRowIndex: beginningRowIndex, inputField: inputField, uiHint: uiHint)
             case .date:
                 return RSDDateTableItemGroup(beginningRowIndex: beginningRowIndex, inputField: inputField, uiHint: uiHint)
-            case .decimal, .integer, .year, .fraction:
+            case .decimal, .integer, .year, .fraction, .duration:
                 return RSDNumberTableItemGroup(beginningRowIndex: beginningRowIndex, inputField: inputField, uiHint: uiHint)
             }
         }

--- a/ResearchSuite/ResearchSuite/RSDFractionFormatter.h
+++ b/ResearchSuite/ResearchSuite/RSDFractionFormatter.h
@@ -48,9 +48,9 @@ typedef struct {
 
 @end
 
-/// `RSDFractionFormatter` is a custom subclass of the `NSNumberFormatter` that can convert a number
-/// to a string with a fractional format, or a fraction to a number -- for example, "3/4" would be converted
-/// to `RSDFraction` with a double value of 0.75.
+/// `RSDFractionFormatter` is a custom subclass of the `NSFormatter` that can convert a number to a string
+/// with a fractional format, or a fraction to a number -- for example, "3/4" would be converted to
+/// `RSDFraction` with a double value of 0.75.
 ///
 /// - note: While this SDK is written in Swift where permissibile, formatters are written in Obj-c to allow
 /// overriding `-getObjectValue:forString:errorDescription:`. Apple documentation does not include how to

--- a/ResearchSuite/ResearchSuite/RSDInputFieldObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDInputFieldObject.swift
@@ -153,11 +153,12 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
     /// Overridable class function for decoding the range from the decoder. The default implementation will key to
     /// `CodingKeys.range` and will decode a range object appropriate to the data type.
     ///
-    /// | RSDFormDataType.BaseType | Type of range to decode                                    |
-    /// |--------------------------|:----------------------------------------------------------:|
-    /// | .integer, .decimal       | `RSDNumberRangeObject`                                     |
-    /// | .date                    | `RSDDateRangeObject`                                       |
-    /// | .year                    | `RSDDateRangeObject` or `RSDNumberRangeObject`             |
+    /// | RSDFormDataType.BaseType      | Type of range to decode                                    |
+    /// |-------------------------------|:----------------------------------------------------------:|
+    /// | .integer, .decimal, .fraction | `RSDNumberRangeObject`                                     |
+    /// | .date                         | `RSDDateRangeObject`                                       |
+    /// | .year                         | `RSDDateRangeObject` or `RSDNumberRangeObject`             |
+    /// | .timeInterval                 | `RSDDurationRangeObject`                               |
     ///
     /// - parameters:
     ///     - decoder: The decoder used to decode this object.
@@ -169,6 +170,8 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
         switch dataType.baseType {
         case .integer, .decimal, .fraction:
             return try container.decodeIfPresent(RSDNumberRangeObject.self, forKey: .range)
+        case .duration:
+            return try container.decodeIfPresent(RSDDurationRangeObject.self, forKey: .range)
         case .date:
             return try container.decodeIfPresent(RSDDateRangeObject.self, forKey: .range)
         case .year:
@@ -181,7 +184,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
             } else {
                 return try container.decodeIfPresent(RSDNumberRangeObject.self, forKey: .range)
             }
-        default:
+        case .string, .boolean:
             return nil
         }
     }
@@ -281,7 +284,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
                 return try container.decode([RSDComparableSurveyRuleObject<String>].self, forKey: .surveyRules)
             case .date:
                 return try container.decode([RSDComparableSurveyRuleObject<Date>].self, forKey: .surveyRules)
-            case .decimal:
+            case .decimal, .duration:
                 return try container.decode([RSDComparableSurveyRuleObject<Double>].self, forKey: .surveyRules)
             case .fraction:
                 return try container.decode([RSDComparableSurveyRuleObject<RSDFraction>].self, forKey: .surveyRules)
@@ -297,7 +300,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
                 rule = try? RSDComparableSurveyRuleObject<String>(from: decoder)
             case .date:
                 rule = try? RSDComparableSurveyRuleObject<Date>(from: decoder)
-            case .decimal:
+            case .decimal, .duration:
                 rule = try? RSDComparableSurveyRuleObject<Double>(from: decoder)
             case .fraction:
                 rule = try? RSDComparableSurveyRuleObject<RSDFraction>(from: decoder)
@@ -473,6 +476,16 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
                                      "maximumValue" : 1.0,
                                      "stepInterval" : 0.25],
                          "matchingAnswer" : 0]
+                
+            case .duration:
+                return [ "identifier" : "timeIntervalExample",
+                         "prompt" : "This is a time interval input field",
+                         "dataType" : "timeInterval",
+                         "uiHint" : "picker",
+                         "placeholderText" : "select a time interval",
+                         "range" : [ "minimumValue" : 0,
+                                     "maximumValue" : 26,
+                                     "unit" : "minute"]]
                 
             case .year:
                 return [ "identifier" : "yearExample",

--- a/ResearchSuite/ResearchSuite/RSDInputFieldObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDInputFieldObject.swift
@@ -158,7 +158,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
     /// | .integer, .decimal, .fraction | `RSDNumberRangeObject`                                     |
     /// | .date                         | `RSDDateRangeObject`                                       |
     /// | .year                         | `RSDDateRangeObject` or `RSDNumberRangeObject`             |
-    /// | .timeInterval                 | `RSDDurationRangeObject`                               |
+    /// | .duration                     | `RSDDurationRangeObject`                                   |
     ///
     /// - parameters:
     ///     - decoder: The decoder used to decode this object.

--- a/ResearchSuite/ResearchSuite/RSDInputFieldTableItemGroup.swift
+++ b/ResearchSuite/ResearchSuite/RSDInputFieldTableItemGroup.swift
@@ -128,7 +128,7 @@ open class RSDInputFieldTableItemGroup : RSDTableItemGroup {
 
 
 /// An item group for entering text.
-final class RSDTextFieldTableItemGroup : RSDInputFieldTableItemGroup {
+public final class RSDTextFieldTableItemGroup : RSDInputFieldTableItemGroup {
     
     /// Default initializer.
     /// - parameters:
@@ -143,7 +143,7 @@ final class RSDTextFieldTableItemGroup : RSDInputFieldTableItemGroup {
 
 
 /// An item group for entering a date.
-final class RSDDateTableItemGroup : RSDInputFieldTableItemGroup {
+public final class RSDDateTableItemGroup : RSDInputFieldTableItemGroup {
     
     /// Default initializer.
     /// - parameters:
@@ -170,10 +170,6 @@ final class RSDDateTableItemGroup : RSDInputFieldTableItemGroup {
         }
         
         let answerType = RSDAnswerResultType(baseType: .date, sequenceType: nil, formDataType: inputField.dataType, dateFormat: dateFormatter?.dateFormat, unit: nil, sequenceSeparator: nil)
-        
-        // TODO: syoung 12/19/2017 Refactor to use an array of RSDNumberInputTableItem to represent the
-        // entry if the preferred uiHint is a text field (rather than a picker).
-        // https://github.com/ResearchKit/SageResearch/issues/7
         let tableItem = RSDTextInputTableItem(rowIndex: beginningRowIndex, inputField: inputField, uiHint: uiHint, answerType: answerType, textFieldOptions: nil, formatter: formatter, pickerSource: pickerSource)
         
         super.init(beginningRowIndex: beginningRowIndex, tableItem: tableItem)
@@ -182,7 +178,7 @@ final class RSDDateTableItemGroup : RSDInputFieldTableItemGroup {
 
 
 /// An item group for entering a number value.
-final class RSDNumberTableItemGroup : RSDInputFieldTableItemGroup {
+public final class RSDNumberTableItemGroup : RSDInputFieldTableItemGroup {
     
     /// Default initializer.
     /// - parameters:
@@ -197,7 +193,7 @@ final class RSDNumberTableItemGroup : RSDInputFieldTableItemGroup {
 
 
 /// An item group for entering data requiring a multiple component format.
-final class RSDMultipleComponentTableItemGroup : RSDInputFieldTableItemGroup {
+public final class RSDMultipleComponentTableItemGroup : RSDInputFieldTableItemGroup {
     
     /// Default initializer.
     /// - parameters:

--- a/ResearchSuite/ResearchSuite/RSDMeasurementInputTableItem.swift
+++ b/ResearchSuite/ResearchSuite/RSDMeasurementInputTableItem.swift
@@ -39,7 +39,7 @@ import Foundation
 /// using ft and in, whereas a child or infant will be reported in inches. The placeholder
 /// text for child or infant measurement range will be either "inches" or "centimeters",
 /// depending upon the user's locale.
-final class RSDHeightInputTableItem : RSDTextInputTableItem {
+public final class RSDHeightInputTableItem : RSDTextInputTableItem {
     
     /// The base unit is the unit of mass that the measurement should be converted to in order
     /// to save the result. Because the `Measurement` class has a generic `UnitType`, it cannot
@@ -107,7 +107,7 @@ final class RSDHeightInputTableItem : RSDTextInputTableItem {
     
     /// Override the `convertAnswer()` function to convert the `Measurement` returned
     /// by the formatter into a decimal value in the `baseUnit`.
-    override func convertAnswer(_ newValue: Any) throws -> Any? {
+    override public func convertAnswer(_ newValue: Any) throws -> Any? {
         let answer = try super.convertAnswer(newValue)
         guard let measurement = answer as? Measurement<UnitLength> else { return answer }
         return measurement.converted(to: baseUnit).value
@@ -119,7 +119,7 @@ final class RSDHeightInputTableItem : RSDTextInputTableItem {
 /// setting the weight of an infant. Typically, US participants know what their newborn baby's
 /// weight is in lb and oz. Additionally, the placeholder text for an adult or child measurement
 /// range will be either "pounds" or "kilograms", depending upon the participant's locale.
-final class RSDMassInputTableItem : RSDTextInputTableItem {
+public final class RSDMassInputTableItem : RSDTextInputTableItem {
     
     /// The base unit is the unit of mass that the measurement should be converted to in order
     /// to save the result. Because the `Measurement` class has a generic `UnitType`, it cannot
@@ -187,7 +187,7 @@ final class RSDMassInputTableItem : RSDTextInputTableItem {
     
     /// Override the `convertAnswer()` function to convert the `Measurement` returned
     /// by the formatter into a decimal value in the `baseUnit`.
-    override func convertAnswer(_ newValue: Any) throws -> Any? {
+    override public func convertAnswer(_ newValue: Any) throws -> Any? {
         let answer = try super.convertAnswer(newValue)
         guard let measurement = answer as? Measurement<UnitMass> else { return answer }
         return measurement.converted(to: baseUnit).value

--- a/ResearchSuite/ResearchSuite/RSDMultipleComponentOptionsObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDMultipleComponentOptionsObject.swift
@@ -35,7 +35,7 @@ import Foundation
 
 /// A simple struct that can be used to implement the `RSDMultipleComponentOptions` protocol.
 public struct RSDMultipleComponentOptionsObject : RSDMultipleComponentOptions {
-    
+
     /// A list of choices for the input field.
     public let choices : [[RSDChoice]]
     
@@ -46,11 +46,15 @@ public struct RSDMultipleComponentOptionsObject : RSDMultipleComponentOptions {
     /// For example, blood pressure would have a separator of "/".
     public let separator: String?
     
+    /// The default answer associated with this option set.
+    public let defaultAnswer: Any?
+    
     /// Default initializer. Auto-synthesized init is not public.
-    public init(choices: [[RSDChoice]], separator: String?, isOptional: Bool) {
+    public init(choices: [[RSDChoice]], separator: String?, isOptional: Bool, defaultAnswer: Any? = nil) {
         self.choices = choices
         self.separator = separator
         self.isOptional = isOptional
+        self.defaultAnswer = defaultAnswer
     }
 }
 

--- a/ResearchSuite/ResearchSuite/RSDNumberPickerDataSourceObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDNumberPickerDataSourceObject.swift
@@ -93,3 +93,6 @@ extension NumberFormatter : RSDNumberFormatterProtocol {
 extension RSDFractionFormatter : RSDNumberFormatterProtocol {
 }
 
+extension RSDDurationFormatter : RSDNumberFormatterProtocol {
+}
+

--- a/ResearchSuite/ResearchSuite/RSDNumberRangeObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDNumberRangeObject.swift
@@ -1,0 +1,202 @@
+//
+//  RSDNumberRangeObject.swift
+//  ResearchSuite
+//
+//  Copyright © 2017-2018 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+/// `RSDNumberRangeObject` extends the properties of an `RSDInputField` for a `decimal` or `integer` data type.
+public struct RSDNumberRangeObject : RSDNumberRange, RSDRangeWithFormatter, Codable {
+    
+    /// The minimum allowed number. When the value of this property is `nil`, there is no minimum.
+    public let minimumValue: Decimal?
+    
+    /// The maximum allowed number. When the value of this property is `nil`, there is no maximum.
+    public let maximumValue: Decimal?
+    
+    /// A step interval to be used for a slider or picker.
+    public let stepInterval: Decimal?
+    
+    /// A unit label associated with this property. The unit should *not* be localized. Instead, this
+    /// value is used to determine the unit for measurements converted to the unit expected by the researcher.
+    ///
+    /// For example, if a measurement of distance is displayed and/or returned by the user in feet, but the
+    /// researcher expects the returned value in meters then the unit here would be "m" and the formatter
+    /// would be a `LengthFormatter` that uses the current locale with a `unitStyle` of `.long`.
+    public let unit: String?
+    
+    /// `Formatter` that is appropriate to the data type. If `nil`, the format will be determined by the UI.
+    /// This is the formatter used to display a previously entered answer to the user or to convert an answer
+    /// entered in a text field into the appropriate value type.
+    ///
+    /// - note: Currently, the `Codable` protocol only supports instantiating a `NumberFormatter` with a
+    ///         "maximumDigits" key that contains the number of decimal places to display.
+    public var formatter: Formatter?
+    
+    /// Default initializer for a `Decimal` range. This is used to initialize the range for a `Decimal` type.
+    ///
+    /// - parameters:
+    ///     - minimumDecimal: The minimum allowed number.
+    ///     - maximumDecimal: The maximum allowed number.
+    ///     - stepInterval: A step interval to be used for a slider or picker.  Default = `nil`.
+    ///     - unit: A unit label associated with this property.  Default = `nil`.
+    ///     - formatter: `NumberFormatter` that is appropriate to the data type. Default = `nil`.
+    public init(minimumDecimal: Decimal?, maximumDecimal: Decimal?, stepInterval: Decimal? = nil, unit: String? = nil, formatter: Formatter? = nil) {
+        self.minimumValue = minimumDecimal
+        self.maximumValue = maximumDecimal
+        self.stepInterval = stepInterval
+        self.unit = unit
+        self.formatter = formatter
+    }
+    
+    /// Default initializer for an `Int` range. This is used to initialize the range for an `Int` type.
+    ///
+    /// - parameters:
+    ///     - minimumInt: The minimum allowed number.
+    ///     - maximumInt: The maximum allowed number.
+    ///     - stepInterval: A step interval to be used for a slider or picker.  Default = `nil`.
+    ///     - unit: A unit label associated with this property.  Default = `nil`.
+    ///     - formatter: `NumberFormatter` that is appropriate to the data type. Default = `nil`.
+    public init(minimumInt: Int?, maximumInt: Int?, stepInterval: Int? = nil, unit: String? = nil, formatter: Formatter? = nil) {
+        self.minimumValue = (minimumInt == nil) ? nil : Decimal(integerLiteral: minimumInt!)
+        self.maximumValue = (maximumInt == nil) ? nil : Decimal(integerLiteral: maximumInt!)
+        self.stepInterval = (stepInterval == nil) ? nil : Decimal(integerLiteral: stepInterval!)
+        self.unit = unit
+        self.formatter = formatter
+    }
+    
+    /// Default initializer for an `Double` range. This is used to initialize the range for a `Double` type.
+    ///
+    /// - parameters:
+    ///     - minimumDouble: The minimum allowed number.
+    ///     - maximumDouble: The maximum allowed number.
+    ///     - stepInterval: A step interval to be used for a slider or picker.  Default = `nil`.
+    ///     - unit: A unit label associated with this property.  Default = `nil`.
+    ///     - formatter: `NumberFormatter` that is appropriate to the data type. Default = `nil`.
+    public init(minimumDouble: Double?, maximumDouble: Double?, stepInterval: Double? = nil, unit: String? = nil, formatter: Formatter? = nil) {
+        self.minimumValue = (minimumDouble == nil) ? nil : Decimal(floatLiteral: minimumDouble!)
+        self.maximumValue = (maximumDouble == nil) ? nil : Decimal(floatLiteral: maximumDouble!)
+        self.stepInterval = (stepInterval == nil) ? nil : Decimal(floatLiteral: stepInterval!)
+        self.unit = unit
+        self.formatter = formatter
+    }
+    
+    private enum CodingKeys : String, CodingKey {
+        case minimumValue, maximumValue, stepInterval, unit, formatter
+    }
+    
+    /// Initialize from a `Decoder`.
+    ///
+    /// - parameter decoder: The decoder to use to decode this instance.
+    /// - throws: `DecodingError`
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let minimumDouble = try container.decodeIfPresent(Double.self, forKey: .minimumValue)
+        let maximumDouble = try container.decodeIfPresent(Double.self, forKey: .maximumValue)
+        let stepInterval = try container.decodeIfPresent(Double.self, forKey: .stepInterval)
+        self.minimumValue = (minimumDouble == nil) ? nil : Decimal(floatLiteral: minimumDouble!)
+        self.maximumValue = (maximumDouble == nil) ? nil : Decimal(floatLiteral: maximumDouble!)
+        self.stepInterval = (stepInterval == nil) ? nil : Decimal(floatLiteral: stepInterval!)
+        self.unit = try container.decodeIfPresent(String.self, forKey: .unit)
+        if container.contains(.formatter) {
+            let nestedDecoder = try container.superDecoder(forKey: .formatter)
+            self.formatter = try decoder.factory.decodeNumberFormatter(from: nestedDecoder)
+        } else {
+            self.formatter = nil
+        }
+    }
+    
+    /// Encode the object to the given encoder.
+    /// - parameter encoder: The encoder to use to encode this instance.
+    /// - throws: `EncodingError`
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        if let obj = (self.minimumValue as NSDecimalNumber?)?.doubleValue {
+            try container.encode(obj, forKey: .minimumValue)
+        }
+        if let obj = (self.maximumValue as NSDecimalNumber?)?.doubleValue {
+            try container.encode(obj, forKey: .maximumValue)
+        }
+        if let obj = (self.stepInterval as NSDecimalNumber?)?.doubleValue  {
+            try container.encode(obj, forKey: .stepInterval)
+        }
+        try container.encodeIfPresent(self.unit, forKey: .unit)
+        
+        if let obj = self.formatter {
+            let nestedEncoder = container.superEncoder(forKey: .formatter)
+            guard let encodable = obj as? Encodable else {
+                throw EncodingError.invalidValue(obj, EncodingError.Context(codingPath: nestedEncoder.codingPath, debugDescription: "The object does not conform to the Encodable protocol"))
+            }
+            try encodable.encode(to: nestedEncoder)
+        }
+    }
+}
+
+extension RSDNumberRangeObject : RSDDocumentableCodableObject {
+    
+    static func codingKeys() -> [CodingKey] {
+        return allCodingKeys()
+    }
+    
+    private static func allCodingKeys() -> [CodingKeys] {
+        let codingKeys: [CodingKeys] = [.minimumValue, .maximumValue, .stepInterval, .unit, .formatter]
+        return codingKeys
+    }
+    
+    static func validateAllKeysIncluded() -> Bool {
+        let keys: [CodingKeys] = allCodingKeys()
+        for (idx, key) in keys.enumerated() {
+            switch key {
+            case .minimumValue:
+                if idx != 0 { return false }
+            case .maximumValue:
+                if idx != 1 { return false }
+            case .stepInterval:
+                if idx != 2 { return false }
+            case .unit:
+                if idx != 3 { return false }
+            case .formatter:
+                if idx != 4 { return false }
+            }
+        }
+        return keys.count == 5
+    }
+    
+    static func numberRangeExamples() -> [RSDNumberRangeObject] {
+        let exampleA = RSDNumberRangeObject(minimumDouble: 1.23, maximumDouble: 567.89, stepInterval: 0.01, unit: "m", formatter: NumberFormatter.defaultNumberFormatter(with: 2))
+        let exampleB = RSDNumberRangeObject(minimumInt: -5, maximumInt: 10)
+        return [exampleA, exampleB]
+    }
+    
+    static func examples() -> [Encodable] {
+        return numberRangeExamples()
+    }
+}

--- a/ResearchSuite/ResearchSuite/RSDNumberRangeObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDNumberRangeObject.swift
@@ -115,6 +115,17 @@ public struct RSDNumberRangeObject : RSDNumberRange, RSDRangeWithFormatter, Coda
     
     /// Initialize from a `Decoder`.
     ///
+    /// - example:
+    ///
+    /// ```
+    ///     { "minimumValue" : 15,
+    ///       "maximumValue" : 360,
+    ///       "stepInterval" : 5,
+    ///       "unit" : "cm",
+    ///       "formatter" : {"maximumDigits" : 3 }
+    ///    }
+    /// ```
+    ///
     /// - parameter decoder: The decoder to use to decode this instance.
     /// - throws: `DecodingError`
     public init(from decoder: Decoder) throws {

--- a/ResearchSuite/ResearchSuite/RSDPickerDataSource.swift
+++ b/ResearchSuite/ResearchSuite/RSDPickerDataSource.swift
@@ -81,6 +81,14 @@ public protocol RSDDatePickerDataSource : RSDPickerDataSource {
 /// A picker data source for selecting choices.
 public protocol RSDChoicePickerDataSource : RSDPickerDataSource {
     
+    /// If this is a multiple component input field, the UI can optionally define a separator.
+    /// For example, blood pressure would have a separator of "/".
+    var separator: String? { get }
+    
+    /// Returns the default answer (if any) for this picker. If `nil` then the UI should display
+    /// empty rows initially, otherwise, the UI should display the default value.
+    var defaultAnswer: Any? { get }
+    
     /// Returns the number of 'columns' to display.
     var numberOfComponents: Int { get }
     
@@ -107,6 +115,14 @@ public protocol RSDChoicePickerDataSource : RSDPickerDataSource {
     func selectedRows(from selectedAnswer: Any?) -> [Int]?
 }
 
+public protocol RSDImageChoicePickerDataSource : RSDPickerDataSource {
+    
+    /// Returns the size of the images for the given component.
+    /// - parameter component: The component (or column) of the picker.
+    /// - returns: The size of the images in that component.
+    func imageSize(forComponent component: Int) -> CGSize
+}
+
 /// A picker data source for picking a number.
 public protocol RSDNumberPickerDataSource : RSDPickerDataSource {
     
@@ -124,7 +140,11 @@ public protocol RSDNumberPickerDataSource : RSDPickerDataSource {
 }
 
 public protocol RSDNumberFormatterProtocol {
+    
+    /// Return the string for the given number.
     func string(from number: NSNumber) -> String?
+    
+    /// Return the number for the given string.
     func number(from string: String) -> NSNumber?
 }
 
@@ -141,10 +161,6 @@ public protocol RSDMultipleComponentChoiceOptions : RSDChoicePickerDataSource {
 ///
 /// - seealso: `RSDMultipleComponentInputField` and `RSDFormStepDataSource`
 public protocol RSDMultipleComponentOptions : RSDMultipleComponentChoiceOptions {
-    
-    /// If this is a multiple component input field, the UI can optionally define a separator.
-    /// For example, blood pressure would have a separator of "/".
-    var separator: String? { get }
 }
 
 /// `RSDChoiceOptions` is a data source protocol that can be used to set up a picker or list of choices.
@@ -157,4 +173,12 @@ public protocol RSDChoiceOptions : RSDChoicePickerDataSource {
     
     /// A Boolean value indicating whether the user can skip the input field without providing an answer.
     var isOptional: Bool { get }
+}
+
+extension RSDChoiceOptions {
+    
+    /// The separator is not used with only one column of choices.
+    public var separator: String? {
+        return nil
+    }
 }

--- a/ResearchSuite/ResearchSuite/RSDRange.swift
+++ b/ResearchSuite/ResearchSuite/RSDRange.swift
@@ -118,7 +118,9 @@ public protocol RSDNumberRange : RSDRange {
 
 public protocol RSDDurationRange : RSDRange {
     
-    /// The minimum allowed duration.
+    /// The minimum allowed duration. The minimum duration should use the `UnitDuration` of the
+    /// base unit that is used to represent the answer.
+    /// - seealso: `RSDAnswerResultType.unit`
     var minimumDuration: Measurement<UnitDuration> { get }
     
     /// The maximum allowed duration. When the value of this property is `nil`, there is no maximum.
@@ -128,6 +130,6 @@ public protocol RSDDurationRange : RSDRange {
     var stepInterval: Int? { get }
     
     /// The duration units that should be included in the formatter and picker used for setting up a
-    /// `.timeInterval` data type.
+    /// `.duration` data type.
     var durationUnits: Set<UnitDuration> { get }
 }

--- a/ResearchSuite/ResearchSuite/RSDRange.swift
+++ b/ResearchSuite/ResearchSuite/RSDRange.swift
@@ -47,7 +47,7 @@ public protocol RSDRangeWithFormatter : RSDRange {
     /// entered in a text field into the appropriate value type.
     ///
     /// - seealso: `RSDAnswerResultType.BaseType` and `RSDFormStepDataSource`
-    var formatter: Formatter? { get }
+    var formatter: Formatter? { get set }
 }
 
 /// `RSDDateRange` defines the range of values appropriate for a `date` data type.
@@ -114,4 +114,20 @@ public protocol RSDNumberRange : RSDRange {
     /// researcher expects the returned value in meters then the unit here would be "m" and the formatter
     /// would be a `LengthFormatter` that uses the current locale with a `unitStyle` of `.long`.
     var unit: String? { get }
+}
+
+public protocol RSDDurationRange : RSDRange {
+    
+    /// The minimum allowed duration.
+    var minimumDuration: Measurement<UnitDuration> { get }
+    
+    /// The maximum allowed duration. When the value of this property is `nil`, there is no maximum.
+    var maximumDuration: Measurement<UnitDuration>? { get }
+    
+    /// A step interval to be used for a slider or picker in the smallest units represented.
+    var stepInterval: Int? { get }
+    
+    /// The duration units that should be included in the formatter and picker used for setting up a
+    /// `.timeInterval` data type.
+    var durationUnits: Set<UnitDuration> { get }
 }

--- a/ResearchSuite/ResearchSuite/RSDSurveyRule.swift
+++ b/ResearchSuite/ResearchSuite/RSDSurveyRule.swift
@@ -44,7 +44,7 @@ public protocol RSDSurveyRule {
 }
 
 /// List of rules creating the survey rule items.
-public enum RSDSurveyRuleOperator: String, Codable {
+public enum RSDSurveyRuleOperator: String, Codable, RSDEnumSet {
     
     /// Survey rule for checking if the skip identifier should apply if the answer was skipped
     /// in which case the result answer value will be `nil`
@@ -75,9 +75,13 @@ public enum RSDSurveyRuleOperator: String, Codable {
     /// defined by the `matchingAnswer`.
     case otherThan          = "ot"
     
-    public static func allRuleOperators() -> [RSDSurveyRuleOperator] {
+    /// List of all the operators.
+    public static var all: Set<RSDSurveyRuleOperator> {
         return [.skip, .equal, .notEqual, .lessThan, .greaterThan, .lessThanEqual, .greaterThanEqual, .otherThan]
     }
+}
+
+extension RSDSurveyRuleOperator : RSDDocumentableEnum {
 }
 
 /// `RSDComparableSurveyRule` is a survey rule that matches an expected result to the answer and vends a skip
@@ -241,8 +245,4 @@ extension RSDComparable {
     }
 }
 
-extension RSDSurveyRuleOperator : RSDDocumentableEnum {
-    static func allCodingKeys() -> [String] {
-        return allRuleOperators().map { $0.rawValue }
-    }
-}
+

--- a/ResearchSuite/ResearchSuite/RSDTextFieldOptionsObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDTextFieldOptionsObject.swift
@@ -198,17 +198,21 @@ extension RSDTextFieldOptionsObject : RSDDocumentableCodableObject {
 
 /// `Codable` enum for the auto-capitalization type for an input text field.
 /// - keywords: ["none", "words", "sentences", "allCharacters"]
-public enum RSDTextAutocapitalizationType : String, Codable {
+public enum RSDTextAutocapitalizationType : String, Codable, RSDEnumSet {
     case none, words, sentences, allCharacters
     
-    static func allTypes() -> [RSDTextAutocapitalizationType] {
+    public static var all: Set<RSDTextAutocapitalizationType> {
+        return Set(orderedSet)
+    }
+    
+    static var orderedSet: [RSDTextAutocapitalizationType] {
         return [.none, .words, .sentences, .allCharacters]
     }
 
     /// Return the `UITextAutocapitalizationType` that maps to this enum.
     #if !os(watchOS)
     public func textAutocapitalizationType() -> UITextAutocapitalizationType {
-        guard let idx = RSDTextAutocapitalizationType.allTypes().index(of: self),
+        guard let idx = RSDTextAutocapitalizationType.orderedSet.index(of: self),
             let type = UITextAutocapitalizationType(rawValue: Int(idx))
             else {
                 return .none
@@ -219,24 +223,25 @@ public enum RSDTextAutocapitalizationType : String, Codable {
 }
 
 extension RSDTextAutocapitalizationType : RSDDocumentableEnum {
-    static func allCodingKeys() -> [String] {
-        return allTypes().map { $0.rawValue }
-    }
 }
 
 /// `Codable` enum for the auto-capitalization type for an input text field.
 /// - keywords: ["default", "no", yes"]
-public enum RSDTextAutocorrectionType : String, Codable {
+public enum RSDTextAutocorrectionType : String, Codable, RSDEnumSet {
     case `default`, no, yes
     
-    static func allTypes() -> [RSDTextAutocorrectionType] {
+    public static var all: Set<RSDTextAutocorrectionType> {
+        return Set(orderedSet)
+    }
+    
+    static var orderedSet: [RSDTextAutocorrectionType] {
         return [.default, .no, .yes]
     }
 
     /// Return the `UITextAutocorrectionType` that maps to this enum.
     #if !os(watchOS)
     public func textAutocorrectionType() -> UITextAutocorrectionType {
-        guard let idx = RSDTextAutocorrectionType.allTypes().index(of: self),
+        guard let idx = RSDTextAutocorrectionType.orderedSet.index(of: self),
             let type = UITextAutocorrectionType(rawValue: Int(idx))
             else {
                 return .default
@@ -247,24 +252,25 @@ public enum RSDTextAutocorrectionType : String, Codable {
 }
 
 extension RSDTextAutocorrectionType : RSDDocumentableEnum {
-    static func allCodingKeys() -> [String] {
-        return allTypes().map { $0.rawValue }
-    }
 }
 
 /// `Codable` enum for the spell checking type for an input text field.
 /// - keywords: ["default", "no", yes"]
-public enum RSDTextSpellCheckingType  : String, Codable {
+public enum RSDTextSpellCheckingType  : String, Codable, RSDEnumSet {
     case `default`, no, yes
     
-    static func allTypes() -> [RSDTextSpellCheckingType] {
+    public static var all: Set<RSDTextSpellCheckingType> {
+        return Set(orderedSet)
+    }
+    
+    static var orderedSet: [RSDTextSpellCheckingType] {
         return [.default, .no, .yes]
     }
 
     /// Return the `UITextSpellCheckingType` that maps to this enum.
     #if !os(watchOS)
     public func textSpellCheckingType() -> UITextSpellCheckingType {
-        guard let idx = RSDTextSpellCheckingType.allTypes().index(of: self),
+        guard let idx = RSDTextSpellCheckingType.orderedSet.index(of: self),
             let type = UITextSpellCheckingType(rawValue: Int(idx))
             else {
                 return .default
@@ -275,26 +281,27 @@ public enum RSDTextSpellCheckingType  : String, Codable {
 }
 
 extension RSDTextSpellCheckingType : RSDDocumentableEnum {
-    static func allCodingKeys() -> [String] {
-        return allTypes().map { $0.rawValue }
-    }
 }
 
 /// `Codable` enum for the spell checking type for an input text field.
 /// - keywords: [ "default", "asciiCapable", "numbersAndPunctuation", "URL",
 ///               "numberPad", "phonePad", "namePhonePad", "emailAddress",
 ///               "decimalPad", "twitter", "webSearch", "asciiCapableNumberPad"]
-public enum RSDKeyboardType  : String, Codable {
+public enum RSDKeyboardType  : String, Codable, RSDEnumSet {
     case `default`, asciiCapable, numbersAndPunctuation, URL, numberPad, phonePad, namePhonePad, emailAddress, decimalPad, twitter, webSearch, asciiCapableNumberPad
+    
+    public static var all: Set<RSDKeyboardType> {
+        return Set(orderedSet)
+    }
 
-    static func allTypes() -> [RSDKeyboardType] {
+    static var orderedSet: [RSDKeyboardType] {
         return [.default, .asciiCapable, .numbersAndPunctuation, .URL, .numberPad, .phonePad, .namePhonePad, .emailAddress, .decimalPad, .twitter, .webSearch, .asciiCapableNumberPad]
     }
 
     /// Return the `UIKeyboardType` that maps to this enum.
     #if !os(watchOS)
     public func keyboardType() -> UIKeyboardType {
-        guard let idx = RSDKeyboardType.allTypes().index(of: self),
+        guard let idx = RSDKeyboardType.orderedSet.index(of: self),
             let type = UIKeyboardType(rawValue: Int(idx))
             else {
                 return .default
@@ -305,7 +312,4 @@ public enum RSDKeyboardType  : String, Codable {
 }
 
 extension RSDKeyboardType : RSDDocumentableEnum {
-    static func allCodingKeys() -> [String] {
-        return allTypes().map { $0.rawValue }
-    }
 }

--- a/ResearchSuite/ResearchSuite/RSDTextInputTableItem.swift
+++ b/ResearchSuite/ResearchSuite/RSDTextInputTableItem.swift
@@ -73,7 +73,7 @@ open class RSDTextInputTableItem : RSDInputFieldTableItem {
             switch answerType.baseType {
             case .decimal:
                 return RSDTextFieldOptionsObject(keyboardType: .decimalPad)
-            case .integer, .timeInterval:
+            case .integer:
                 return RSDTextFieldOptionsObject(keyboardType: .numberPad)
             case .date, .string:
                 return RSDTextFieldOptionsObject(keyboardType: .default)
@@ -198,7 +198,7 @@ open class RSDTextInputTableItem : RSDInputFieldTableItem {
                 return NSNumber(value: (string as NSString).boolValue)
             } else if answerType.baseType == .integer {
                 return NSNumber(value: (string as NSString).integerValue)
-            } else if answerType.baseType == .decimal || answerType.baseType == .timeInterval {
+            } else if answerType.baseType == .decimal {
                 return NSNumber(value: (string as NSString).doubleValue)
             } else {
                 let context = RSDInputFieldError.Context(identifier: inputField.identifier, value: answer, answerResult: answerType, debugDescription: "String Type \(answer) is not supported for \(inputField.identifier)")
@@ -217,7 +217,7 @@ open class RSDTextInputTableItem : RSDInputFieldTableItem {
             switch answerType.baseType  {
             case .boolean:
                 return num.boolValue
-            case .integer, .decimal, .timeInterval:
+            case .integer, .decimal:
                 return num
             default:
                 let context = RSDInputFieldError.Context(identifier: inputField.identifier, value: answer, answerResult: answerType, debugDescription: "Number Type \(answer) is not supported for \(inputField.identifier)")

--- a/ResearchSuite/ResearchSuite/RSDUIThemeElement.swift
+++ b/ResearchSuite/ResearchSuite/RSDUIThemeElement.swift
@@ -113,7 +113,7 @@ public protocol RSDColorThemeElement : RSDUIThemeElement {
 }
 
 /// A hint as to where the UI should place an image.
-public enum RSDImagePlacementType : String, Codable {
+public enum RSDImagePlacementType : String, Codable, RSDEnumSet {
     
     /// Smaller presentation of an icon image before the content.
     case iconBefore
@@ -128,15 +128,12 @@ public enum RSDImagePlacementType : String, Codable {
     case topBackground
     
     /// Return all the types defined in this enum.
-    public static func allTypes() -> [RSDImagePlacementType] {
+    public static var all: Set<RSDImagePlacementType> {
         return [.iconBefore, .iconAfter, .fullsizeBackground, .topBackground]
     }
 }
 
 extension RSDImagePlacementType : RSDDocumentableEnum {
-    static func allCodingKeys() -> [String] {
-        return allTypes().map { $0.rawValue }
-    }
 }
 
 /// `RSDImageThemeElement` extends the UI step to include an image.

--- a/ResearchSuite/ResearchSuite/RSDUSMeasurementPickerDataSource.swift
+++ b/ResearchSuite/ResearchSuite/RSDUSMeasurementPickerDataSource.swift
@@ -48,6 +48,11 @@ public protocol RSDUSMeasurementPickerDataSource : RSDMultipleComponentChoiceOpt
 
 extension RSDUSMeasurementPickerDataSource {
     
+    /// US measurement pickers do not have a default answer.
+    public var defaultAnswer: Any? {
+        return nil
+    }
+    
     /// Returns the selected answer created by the union of the selected rows.
     /// - parameter selectedRows: The selected rows, where there is a selected row for each component.
     /// - returns: The answer created from the given array of selected rows.
@@ -78,6 +83,9 @@ extension RSDUSMeasurementPickerDataSource {
 /// `RSDUSHeightPickerDataSourceObject` is a custom height picker for use when the `Locale`
 /// uses US Customary units (not metric system).
 public struct RSDUSHeightPickerDataSourceObject : RSDUSMeasurementPickerDataSource {
+    
+    /// The separator is not used with the height picker.
+    public let separator: String? = nil
     
     // The US Customary unit converter.
     public let converter: RSDUnitConverter.USCustomaryUnitConverter<UnitLength>
@@ -145,6 +153,9 @@ extension RSDLengthFormatter {
 /// `RSDUSInfantMassPickerDataSource` is a custom weight picker for use when the `Locale`
 /// uses US Customary units (not metric system) and the mass is for an infant in "lb, oz".
 public struct RSDUSInfantMassPickerDataSourceObject : RSDUSMeasurementPickerDataSource {
+    
+    /// The separator is not used with the mass picker.
+    public let separator: String? = nil
     
     // The US Customary unit converter.
     public let converter: RSDUnitConverter.USCustomaryUnitConverter<UnitMass>

--- a/ResearchSuite/ResearchSuite/ResearchSuite.h
+++ b/ResearchSuite/ResearchSuite/ResearchSuite.h
@@ -41,6 +41,7 @@ FOUNDATION_EXPORT const unsigned char ResearchSuiteVersionString[];
 
 #import <Researchsuite/RSDExceptionHandler.h>
 #import <Researchsuite/NSUnit+RSDUnitConversion.h>
+#import <Researchsuite/RSDDurationFormatter.h>
 #import <Researchsuite/RSDFractionFormatter.h>
 #import <Researchsuite/RSDLengthFormatter.h>
 #import <Researchsuite/RSDMassFormatter.h>

--- a/ResearchSuite/ResearchSuite/SequenceType+Utilities.swift
+++ b/ResearchSuite/ResearchSuite/SequenceType+Utilities.swift
@@ -31,8 +31,21 @@
 
 import Foundation
 
-
 extension Sequence {
+    
+    /// Returns an `Set` containing the results of mapping and filtering `transform`
+    /// over `self`.
+    /// - parameter transform: The method which returns either the transformed element or `nil` if filtered.
+    /// - returns: A set of the transformed elements.
+    public func rsd_mapAndFilterSet<T : Hashable>(_ transform: (Self.Iterator.Element) throws -> T?) rethrows -> Set<T> {
+        var result = Set<T>()
+        for element in self {
+            if let t = try transform(element) {
+                result.insert(t)
+            }
+        }
+        return result
+    }
     
     /// Returns an `Array` containing the results of mapping and filtering `transform`
     /// over `self`.

--- a/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableResultObjectTests.swift
+++ b/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableResultObjectTests.swift
@@ -318,55 +318,6 @@ class CodableResultObjectTests: XCTestCase {
         }
     }
     
-    func testAnswerResultObject_TimeInterval_Codable() {
-        let json = """
-        {
-            "identifier": "foo",
-            "type": "bar",
-            "startDate": "2017-10-16T22:28:09.000-07:00",
-            "endDate": "2017-10-16T22:30:09.000-07:00",
-            "answerType": {"baseType" : "timeInterval"},
-            "value": 12.5
-        }
-        """.data(using: .utf8)! // our data in native (JSON) format
-        
-        do {
-            
-            let object = try decoder.decode(RSDAnswerResultObject.self, from: json)
-            
-            XCTAssertEqual(object.identifier, "foo")
-            XCTAssertEqual(object.type, "bar")
-            XCTAssertGreaterThan(object.endDate, object.startDate)
-            
-            let expectedAnswerType = RSDAnswerResultType(baseType: .timeInterval)
-            XCTAssertEqual(object.answerType, expectedAnswerType)
-            
-            XCTAssertEqual(object.value as? TimeInterval, 12.5)
-            
-            let jsonData = try encoder.encode(object)
-            guard let dictionary = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String : Any]
-                else {
-                    XCTFail("Encoded object is not a dictionary")
-                    return
-            }
-            
-            XCTAssertEqual(dictionary["identifier"] as? String, "foo")
-            XCTAssertEqual(dictionary["type"] as? String, "bar")
-            XCTAssertEqual(dictionary["startDate"] as? String, "2017-10-16T22:28:09.000-07:00")
-            XCTAssertEqual(dictionary["endDate"] as? String, "2017-10-16T22:30:09.000-07:00")
-            XCTAssertEqual(dictionary["value"] as? TimeInterval, 12.5)
-            if let answerType = dictionary["answerType"] as? [String:Any] {
-                XCTAssertEqual(answerType["baseType"] as? String, "timeInterval")
-            }
-            else {
-                XCTFail("Encoded object does not include the answerType")
-            }
-            
-        } catch let err {
-            XCTFail("Failed to decode/encode object: \(err)")
-        }
-    }
-    
     func testAnswerResultObject_Date_Codable() {
         let json = """
         {
@@ -601,69 +552,6 @@ class CodableResultObjectTests: XCTestCase {
             }
             if let answerType = dictionary["answerType"] as? [String:Any] {
                 XCTAssertEqual(answerType["baseType"] as? String, "decimal")
-                XCTAssertEqual(answerType["sequenceType"] as? String, "array")
-            }
-            else {
-                XCTFail("Encoded object does not include the answerType")
-            }
-            
-        } catch let err {
-            XCTFail("Failed to decode/encode object: \(err)")
-        }
-    }
-    
-    func testAnswerResultObject_TimeIntervalArray_Codable() {
-        let json = """
-        {
-            "identifier": "foo",
-            "type": "bar",
-            "startDate": "2017-10-16T22:28:09.000-07:00",
-            "endDate": "2017-10-16T22:30:09.000-07:00",
-            "answerType": {"baseType" : "timeInterval", "sequenceType" : "array"},
-            "value": [65.3, 47.2, 99.8]
-        }
-        """.data(using: .utf8)! // our data in native (JSON) format
-        
-        do {
-            
-            let object = try decoder.decode(RSDAnswerResultObject.self, from: json)
-            
-            XCTAssertEqual(object.identifier, "foo")
-            XCTAssertEqual(object.type, "bar")
-            XCTAssertGreaterThan(object.endDate, object.startDate)
-            
-            let expectedAnswerType = RSDAnswerResultType(baseType: .timeInterval, sequenceType: .array)
-            XCTAssertEqual(object.answerType, expectedAnswerType)
-            
-            XCTAssertNotNil(object.value)
-            if let array = object.value as? [TimeInterval] {
-                XCTAssertEqual(array.count, 3)
-                XCTAssertEqual(array.first, 65.3)
-                XCTAssertEqual(array.last, 99.8)
-            }
-            else {
-                XCTFail("Failed to decode the array value \(String(describing: object.value))")
-            }
-            
-            let jsonData = try encoder.encode(object)
-            guard let dictionary = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String : Any]
-                else {
-                    XCTFail("Encoded object is not a dictionary")
-                    return
-            }
-            
-            XCTAssertEqual(dictionary["identifier"] as? String, "foo")
-            XCTAssertEqual(dictionary["type"] as? String, "bar")
-            XCTAssertEqual(dictionary["startDate"] as? String, "2017-10-16T22:28:09.000-07:00")
-            XCTAssertEqual(dictionary["endDate"] as? String, "2017-10-16T22:30:09.000-07:00")
-            if let values = dictionary["value"] as? [Double] {
-                XCTAssertEqual(values, [65.3, 47.2, 99.8])
-            }
-            else {
-                XCTFail("Failed to encode the values. \(dictionary)")
-            }
-            if let answerType = dictionary["answerType"] as? [String:Any] {
-                XCTAssertEqual(answerType["baseType"] as? String, "timeInterval")
                 XCTAssertEqual(answerType["sequenceType"] as? String, "array")
             }
             else {

--- a/ResearchSuite/ResearchSuiteTests/DataSource Tests/FormatterTests.swift
+++ b/ResearchSuite/ResearchSuiteTests/DataSource Tests/FormatterTests.swift
@@ -332,4 +332,118 @@ class FormatterTests: XCTestCase {
         let success = formatter.getObjectValue(&obj, for: inputString, errorDescription: &err)
         XCTAssertFalse(success)
     }
+    
+    func testDurationFormatter_1hour_2minute_full() {
+        NSLocale.setCurrentTest(Locale(identifier: "en_US"))
+
+        let inputString = "1 hour, 30 minutes"
+        let expectedValue = Double(90)
+        let measurement = NSNumber(value: expectedValue)
+        
+        let formatter = RSDDurationFormatter()
+        formatter.toStringUnit = .minutes
+        formatter.fromStringUnit = .minutes
+        formatter.unitsStyle = .full
+        
+        let text = formatter.string(for: measurement)
+        XCTAssertEqual(text, inputString)
+        
+        var obj: AnyObject?
+        var err: NSString?
+        let success = formatter.getObjectValue(&obj, for: inputString, errorDescription: &err)
+        XCTAssertTrue(success)
+        XCTAssertNil(err)
+        if let output = obj as? Measurement<UnitDuration> {
+            let value = output.converted(to: .minutes).value
+            XCTAssertEqual(value, expectedValue)
+        } else {
+            XCTFail("Failed to convert string to inches")
+        }
+    }
+    
+    func testDurationFormatter_1hour_2minute_positional() {
+        NSLocale.setCurrentTest(Locale(identifier: "en_US"))
+        
+        let inputString = "1:30"
+        let expectedValue = Double(90)
+        let measurement = NSNumber(value: expectedValue)
+        
+        let formatter = RSDDurationFormatter()
+        formatter.toStringUnit = .minutes
+        formatter.fromStringUnit = .minutes
+        formatter.unitsStyle = .positional
+        formatter.allowedUnits = [.hour, .minute]
+        
+        let text = formatter.string(for: measurement)
+        XCTAssertEqual(text, inputString)
+        
+        var obj: AnyObject?
+        var err: NSString?
+        let success = formatter.getObjectValue(&obj, for: inputString, errorDescription: &err)
+        XCTAssertTrue(success)
+        XCTAssertNil(err)
+        if let output = obj as? Measurement<UnitDuration> {
+            let value = output.converted(to: .minutes).value
+            XCTAssertEqual(value, expectedValue)
+        } else {
+            XCTFail("Failed to convert string to inches")
+        }
+    }
+    
+    func testDurationFormatter_2minute_30second_full() {
+        NSLocale.setCurrentTest(Locale(identifier: "en_US"))
+        
+        let inputString = "2 minutes, 30 seconds"
+        let expectedValue = Double(150)
+        let measurement = NSNumber(value: expectedValue)
+        
+        let formatter = RSDDurationFormatter()
+        formatter.toStringUnit = .seconds
+        formatter.fromStringUnit = .seconds
+        formatter.unitsStyle = .full
+        
+        let text = formatter.string(for: measurement)
+        XCTAssertEqual(text, inputString)
+        
+        var obj: AnyObject?
+        var err: NSString?
+        let success = formatter.getObjectValue(&obj, for: inputString, errorDescription: &err)
+        XCTAssertTrue(success)
+        XCTAssertNil(err)
+        if let output = obj as? Measurement<UnitDuration> {
+            let value = output.converted(to: .seconds).value
+            XCTAssertEqual(value, expectedValue)
+        } else {
+            XCTFail("Failed to convert string to inches")
+        }
+    }
+    
+    func testDurationFormatter_2minute_30second_positional() {
+        NSLocale.setCurrentTest(Locale(identifier: "en_US"))
+        
+        let inputString = "2:30"
+        let expectedValue = Double(150)
+        let measurement = NSNumber(value: expectedValue)
+        
+        let formatter = RSDDurationFormatter()
+        formatter.toStringUnit = .seconds
+        formatter.fromStringUnit = .seconds
+        formatter.unitsStyle = .positional
+        formatter.allowedUnits = [.minute, .second]
+        
+        let text = formatter.string(for: measurement)
+        XCTAssertEqual(text, inputString)
+        
+        var obj: AnyObject?
+        var err: NSString?
+        let success = formatter.getObjectValue(&obj, for: inputString, errorDescription: &err)
+        XCTAssertTrue(success)
+        XCTAssertNil(err)
+        if let output = obj as? Measurement<UnitDuration> {
+            let value = output.converted(to: .seconds).value
+            XCTAssertEqual(value, expectedValue)
+        } else {
+            XCTFail("Failed to convert string to inches")
+        }
+    }
 }

--- a/ResearchSuite/ResearchSuiteTests/DataSource Tests/PickerDataSourceTests.swift
+++ b/ResearchSuite/ResearchSuiteTests/DataSource Tests/PickerDataSourceTests.swift
@@ -86,6 +86,7 @@ class PickerDataSourceTests: XCTestCase {
     }
     
     func testHeightPicker() {
+        NSLocale.setCurrentTest(Locale(identifier: "en_US"))
         
         let picker = RSDUSHeightPickerDataSourceObject()
         
@@ -116,6 +117,7 @@ class PickerDataSourceTests: XCTestCase {
     }
     
     func testWeightPicker() {
+        NSLocale.setCurrentTest(Locale(identifier: "en_US"))
         
         let picker = RSDUSInfantMassPickerDataSourceObject()
         
@@ -169,7 +171,9 @@ class PickerDataSourceTests: XCTestCase {
         XCTAssertEqual(text, "cat")
     }
     
-    func testRSDNumberPickerDataSource() {
+    func testNumberPickerDataSource() {
+        NSLocale.setCurrentTest(Locale(identifier: "en_US"))
+
         let formatter = NumberFormatter.defaultNumberFormatter(with: 1)
         let picker = RSDNumberPickerDataSourceObject(minimum: -1.0, maximum: 1.0, stepInterval: 0.2, numberFormatter: formatter)
         
@@ -180,5 +184,107 @@ class PickerDataSourceTests: XCTestCase {
         
         let textAnswer = picker.textAnswer(from: inputAnswer)
         XCTAssertEqual(textAnswer, "0.8")
+    }
+    
+    func testTimeIntervalPickerDataSource_MinuteSecond() {
+        NSLocale.setCurrentTest(Locale(identifier: "en_US"))
+
+        let range = RSDDurationRangeObject(durationUnits: [.seconds, .minutes])
+        
+        // Confirm assumptions about defaults
+        XCTAssertEqual(range.baseUnit, .seconds)
+        XCTAssertEqual(range.minimumDuration, Measurement(value: 0, unit: UnitDuration.seconds))
+        
+        guard let picker = RSDDurationPickerDataSourceObject(range: range)
+            else {
+                XCTFail("Failed to instantiate a picker from the given range")
+                return
+        }
+        
+        XCTAssertEqual(picker.numberOfComponents, 2)
+        
+        // minute field
+        XCTAssertEqual(picker.numberOfRows(in: 0), 61)
+        XCTAssertEqual(picker.componentChoices[0].first?.value as? Int, 0)
+        XCTAssertEqual(picker.componentChoices[0].last?.value as? Int, 60)
+
+        // second field
+        XCTAssertEqual(picker.numberOfRows(in: 1), 60)
+        XCTAssertEqual(picker.componentChoices[1].first?.value as? Int, 0)
+        XCTAssertEqual(picker.componentChoices[1].last?.value as? Int, 59)
+        
+        let inputAnswer = Double(90)
+        let expectedRows = [1, 30]
+        let expectedMinutes = 1
+        let expectedSeconds = 30
+        let expectedText = "1:30"
+        
+        if let rows = picker.selectedRows(from: inputAnswer) {
+            XCTAssertEqual(rows, expectedRows)
+            if rows.count == 2 {
+                XCTAssertEqual(picker.choice(forRow: rows[0], forComponent: 0)?.value as? Int, expectedMinutes)
+                XCTAssertEqual(picker.choice(forRow: rows[1], forComponent: 1)?.value as? Int, expectedSeconds)
+            } else {
+                XCTFail("Row count does not match expected. \(rows)")
+            }
+        } else {
+            XCTFail("Failed to get the rows for an answer within range")
+        }
+        
+        let textAnswer = picker.textAnswer(from: inputAnswer)
+        XCTAssertEqual(textAnswer, expectedText)
+        
+        XCTAssertEqual(picker.selectedAnswer(with: expectedRows) as? Double, inputAnswer)
+    }
+    
+    func testTimeIntervalPickerDataSource_HourMinute() {
+        NSLocale.setCurrentTest(Locale(identifier: "en_US"))
+
+        let range = RSDDurationRangeObject(durationUnits: [.minutes, .hours])
+        
+        // Confirm assumptions about defaults
+        XCTAssertEqual(range.baseUnit, .minutes)
+        XCTAssertEqual(range.minimumDuration, Measurement(value: 0, unit: UnitDuration.minutes))
+        
+        guard let picker = RSDDurationPickerDataSourceObject(range: range)
+            else {
+                XCTFail("Failed to instantiate a picker from the given range")
+                return
+        }
+        
+        XCTAssertEqual(picker.numberOfComponents, 2)
+        
+        // hour field
+        XCTAssertEqual(picker.numberOfRows(in: 0), 25)
+        XCTAssertEqual(picker.componentChoices[0].first?.value as? Int, 0)
+        XCTAssertEqual(picker.componentChoices[0].last?.value as? Int, 24)
+        
+        // minute field
+        XCTAssertEqual(picker.numberOfRows(in: 1), 60)
+        XCTAssertEqual(picker.componentChoices[1].first?.value as? Int, 0)
+        XCTAssertEqual(picker.componentChoices[1].last?.value as? Int, 59)
+        
+        let inputAnswer = Double(90)
+        let expectedRows = [1, 30]
+        let expectedHours = 1
+        let expectedMinutes = 30
+        let expectedText = "1:30"
+        
+        if let rows = picker.selectedRows(from: inputAnswer) {
+            XCTAssertEqual(rows, expectedRows)
+            if rows.count == 2 {
+                XCTAssertEqual(picker.choice(forRow: rows[0], forComponent: 0)?.value as? Int, expectedHours)
+                XCTAssertEqual(picker.choice(forRow: rows[1], forComponent: 1)?.value as? Int, expectedMinutes)
+            } else {
+                XCTFail("Row count does not match expected. \(rows)")
+            }
+        } else {
+            XCTFail("Failed to get the rows for an answer within range")
+        }
+        
+        let textAnswer = picker.textAnswer(from: inputAnswer)
+        XCTAssertEqual(textAnswer, expectedText)
+        
+        XCTAssertEqual(picker.selectedAnswer(with: expectedRows) as? Double, inputAnswer)
     }
 }

--- a/ResearchSuite/ResearchSuiteTests/ModelObject Tests/MeasurementDurationTests.swift
+++ b/ResearchSuite/ResearchSuiteTests/ModelObject Tests/MeasurementDurationTests.swift
@@ -1,0 +1,119 @@
+//
+//  MeasurementDurationTests.swift
+//  ResearchSuite
+//
+//  Copyright © 2018 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+
+import XCTest
+
+@testable import ResearchSuite
+
+class MeasurementDurationTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testMeasurementDuration_ValueAndUnit_3h_15m() {
+        let expectedHours = 3
+        let expectedMinutes = 15
+        let expectedSeconds = 0
+        let timeInterval: TimeInterval  = TimeInterval(expectedHours * 3600 + expectedMinutes * 60 + expectedSeconds)
+        let ti = Measurement(value: timeInterval, unit: UnitDuration.seconds)
+        
+        XCTAssertEqual(ti.hours, expectedHours)
+        XCTAssertEqual(ti.minutes, expectedMinutes)
+        XCTAssertEqual(ti.seconds, expectedSeconds)
+        XCTAssertEqual(ti.component(of: .hours), expectedHours)
+        XCTAssertEqual(ti.component(of: .minutes), expectedMinutes)
+        XCTAssertEqual(ti.component(of: .seconds), expectedSeconds)
+        XCTAssertEqual(ti.timeInterval, timeInterval)
+    }
+    
+    func testTimeInterval_ValueAndUnit_2h_15m_20s() {
+        let expectedHours = 2
+        let expectedMinutes = 15
+        let expectedSeconds = 20
+        let timeInterval: TimeInterval  = TimeInterval(expectedHours * 3600 + expectedMinutes * 60 + expectedSeconds)
+        let ti = Measurement(value: timeInterval, unit: UnitDuration.seconds)
+        
+        XCTAssertEqual(ti.hours, expectedHours)
+        XCTAssertEqual(ti.minutes, expectedMinutes)
+        XCTAssertEqual(ti.seconds, expectedSeconds)
+        XCTAssertEqual(ti.component(of: .hours), expectedHours)
+        XCTAssertEqual(ti.component(of: .minutes), expectedMinutes)
+        XCTAssertEqual(ti.component(of: .seconds), expectedSeconds)
+        XCTAssertEqual(ti.timeInterval, timeInterval)
+    }
+    
+    func testTimeInterval_ValueAndUnit_10m_20s() {
+        let expectedHours = 0
+        let expectedMinutes = 10
+        let expectedSeconds = 20
+        let timeInterval: TimeInterval  = TimeInterval(expectedHours * 3600 + expectedMinutes * 60 + expectedSeconds)
+        let ti = Measurement(value: timeInterval, unit: UnitDuration.seconds)
+        
+        XCTAssertEqual(ti.hours, expectedHours)
+        XCTAssertEqual(ti.minutes, expectedMinutes)
+        XCTAssertEqual(ti.seconds, expectedSeconds)
+        XCTAssertEqual(ti.component(of: .hours), expectedHours)
+        XCTAssertEqual(ti.component(of: .minutes), expectedMinutes)
+        XCTAssertEqual(ti.component(of: .seconds), expectedSeconds)
+        XCTAssertEqual(ti.timeInterval, timeInterval)
+    }
+    
+    func testTimeIntervalUnit_MaxTimeValue() {
+        XCTAssertEqual(UnitDuration.hours.maxTimeValue(), 24)
+        XCTAssertEqual(UnitDuration.minutes.maxTimeValue(), 60)
+        XCTAssertEqual(UnitDuration.seconds.maxTimeValue(), 60)
+    }
+    
+    func testTimeIntervalUnit_Comparable() {
+        XCTAssertGreaterThan(UnitDuration.hours, UnitDuration.minutes)
+        XCTAssertGreaterThan(UnitDuration.minutes, UnitDuration.seconds)
+        XCTAssertGreaterThan(UnitDuration.hours, UnitDuration.seconds)
+    }
+    
+    func testDurationUnitConvertion() {
+        XCTAssertEqual(UnitDuration(fromSymbol: "s"), UnitDuration.seconds)
+        XCTAssertEqual(UnitDuration(fromSymbol: "seconds"), UnitDuration.seconds)
+        XCTAssertEqual(UnitDuration(fromSymbol: "min"), UnitDuration.minutes)
+        XCTAssertEqual(UnitDuration(fromSymbol: "minutes"), UnitDuration.minutes)
+        XCTAssertEqual(UnitDuration(fromSymbol: "hr"), UnitDuration.hours)
+        XCTAssertEqual(UnitDuration(fromSymbol: "hours"), UnitDuration.hours)
+    }
+}

--- a/ResearchSuiteTestApp/ResearchSuiteTestApp/Resources/JSON/TaskFoo.json
+++ b/ResearchSuiteTestApp/ResearchSuiteTestApp/Resources/JSON/TaskFoo.json
@@ -115,6 +115,11 @@
                               "dataType": "multipleComponent",
                               "prompt": "Pick a combination of colors and animals",
                               "choices" : [["blue", "red", "green", "yellow"], ["dog", "cat", "rat", "duck"]]
+                              },
+                              {
+                              "identifier": "duration",
+                              "dataType": "duration",
+                              "prompt": "Pick a time interval"
                               }
                               ]
               },

--- a/ResearchSuiteUI/ResearchSuiteUI/iOS/Views/RSDPickerViewProtocol.swift
+++ b/ResearchSuiteUI/ResearchSuiteUI/iOS/Views/RSDPickerViewProtocol.swift
@@ -204,7 +204,7 @@ open class RSDChoicePickerView : UIPickerView, RSDPickerViewProtocol, UIPickerVi
         }
     }
     
-    /// Override super to return the number of rows for each comonent returned by the picker
+    /// Override super to return the number of rows for each component returned by the picker
     /// source because this is the `UIPickerViewDataSource` for itself and therefore calling this
     /// method can cause returning `0` or an infinite loop of wacky madness.
     open override func numberOfRows(inComponent component: Int) -> Int {
@@ -222,7 +222,7 @@ open class RSDChoicePickerView : UIPickerView, RSDPickerViewProtocol, UIPickerVi
     }
     
     /// Returns the array of components that map to the components of the picker.
-    /// This is needed because the separator is displayed using it's own row.
+    /// This is needed because the separator is displayed using its own row.
     /// By doing so, the separator will appear stationary while the rows spin to
     /// either side of the separator.
     func pickerComponents() -> [Int] {
@@ -276,7 +276,7 @@ open class RSDChoicePickerView : UIPickerView, RSDPickerViewProtocol, UIPickerVi
     }
     
     /// Return a view to use for this picker. By default, this method returns a label that is
-    /// alligned with the components center aligned.
+    /// aligned with the components center aligned.
     open func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
         let label = (view as? UILabel) ?? instantiateLabel(for: component)
         label.text = self.pickerView(self, titleForRow: row, forComponent: component)

--- a/ResearchSuiteUI/ResearchSuiteUI/iOS/Views/RSDPickerViewProtocol.swift
+++ b/ResearchSuiteUI/ResearchSuiteUI/iOS/Views/RSDPickerViewProtocol.swift
@@ -129,28 +129,6 @@ open class RSDChoicePickerView : UIPickerView, RSDPickerViewProtocol, UIPickerVi
     /// The picker view data source for this view. This is a strong reference.
     public var pickerSource: RSDChoicePickerDataSource!
     
-    /// The answer maps to the values for the selected rows.
-    public var answer: Any? {
-        get {
-            var selections: [Int] = []
-            for ii in 0..<self.numberOfComponents {
-                let selectedRow = self.selectedRow(inComponent: ii) - 1
-                guard selectedRow >= 0 else { return nil }
-                selections.append(selectedRow)
-            }
-            return pickerSource.selectedAnswer(with: selections)
-        }
-        set {
-            guard let selectedRows = pickerSource.selectedRows(from: newValue)
-                else {
-                    return
-            }
-            for (component, row) in selectedRows.enumerated() {
-                self.selectRow(row + 1, inComponent: component, animated: false)
-            }
-        }
-    }
-    
     /// Default initializer.
     /// - parameters:
     ///     - pickerSource: The picker source used to set up the picker.
@@ -163,31 +141,215 @@ open class RSDChoicePickerView : UIPickerView, RSDPickerViewProtocol, UIPickerVi
         self.dataSource = self
     }
     
+    /// Required initialized.
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-
-    // MARK: UIPickerViewDataSource
     
-    open func numberOfComponents(in pickerView: UIPickerView) -> Int {
-        return pickerSource.numberOfComponents
+    /// The answer maps to the values for the selected rows.
+    public var answer: Any? {
+        get {
+            let components = self.pickerComponents()
+            let selections = components.rsd_mapAndFilter { (pickerComponent) -> Int? in
+                let selectedRow = self.selectedRow(inComponent: pickerComponent) - rowOffset
+                return selectedRow >= 0 ? selectedRow : nil
+            }
+            guard selections.count == components.count else { return nil }
+            return pickerSource.selectedAnswer(with: selections)
+        }
+        set {
+            let components = self.pickerComponents()
+            if hasSeparator {
+                let componentsCount = self.numberOfComponents
+                for ii in components {
+                    let separatorComponent = ii + 1
+                    if separatorComponent < componentsCount {
+                        self.selectRow(0, inComponent: separatorComponent, animated: false)
+                    }
+                }
+            }
+            guard let selectedRows = pickerSource.selectedRows(from: newValue ?? pickerSource.defaultAnswer)
+                else {
+                    return
+            }
+            for (componentIndex, row) in selectedRows.enumerated() {
+                guard componentIndex < components.count else { return }
+                let selectedRow = row + rowOffset
+                let selectedComponent = components[componentIndex]
+                self.selectRow(selectedRow, inComponent: selectedComponent, animated: false)
+            }
+        }
     }
     
+    /// Returns `true` if the picker source has a separator between fields.
+    open var hasSeparator: Bool {
+        return pickerSource.separator?.count ?? 0 > 0
+    }
+    
+    /// Returns the row offset for the picker source. By default, this equals `1` to allow
+    /// showing an empty row, *unless* there is a non-nil default answer in which case this
+    /// will return `0`.
+    open var rowOffset: Int {
+        return pickerSource.defaultAnswer == nil ? 1 : 0
+    }
+    
+    /// Override super to return the number of components returned by the picker source
+    /// because this is the `UIPickerViewDataSource` for itself and therefore calling this
+    /// method can cause returning `0` or an infinite loop of wacky madness.
+    open override var numberOfComponents: Int {
+        if hasSeparator {
+            return pickerSource.numberOfComponents * 2 - 1
+        } else {
+            return pickerSource.numberOfComponents
+        }
+    }
+    
+    /// Override super to return the number of rows for each comonent returned by the picker
+    /// source because this is the `UIPickerViewDataSource` for itself and therefore calling this
+    /// method can cause returning `0` or an infinite loop of wacky madness.
+    open override func numberOfRows(inComponent component: Int) -> Int {
+        guard let pickerComponent = transformedComponent(component) else {
+            return hasSeparator ? 1 : 0
+        }
+        return pickerSource.numberOfRows(in: pickerComponent) + rowOffset
+    }
+    
+    /// Transform the component into the components for the picker source, or return `nil`
+    /// if this is a separator row.
+    func transformedComponent(_ component: Int) -> Int? {
+        guard let idx = pickerComponents().index(of: component) else { return nil }
+        return idx
+    }
+    
+    /// Returns the array of components that map to the components of the picker.
+    /// This is needed because the separator is displayed using it's own row.
+    /// By doing so, the separator will appear stationary while the rows spin to
+    /// either side of the separator.
+    func pickerComponents() -> [Int] {
+        let strideBy = hasSeparator ? 2 : 1
+        return Array(stride(from: 0, to: self.numberOfComponents, by: strideBy))
+    }
+    
+    /// Is the given component a separator component?
+    /// - parameter component: The component in this picker view.
+    func isSeparatorComponent(_ component: Int) -> Bool {
+        return transformedComponent(component) == nil
+    }
+    
+    /// Returns the choice associated with the given row.
+    /// - parameters:
+    ///     - row: The row in this picker view.
+    ///     - component: The component in this picker view.
+    open func choice(forRow row: Int, forComponent component: Int) -> RSDChoice? {
+        let pickerRow = row - rowOffset
+        guard let pickerComponent = transformedComponent(component), pickerRow >= 0 else {
+            return nil
+        }
+        return pickerSource.choice(forRow: pickerRow, forComponent: pickerComponent)
+    }
+    
+    // MARK: UIPickerViewDataSource
+    
+    /// returns the number of 'columns' to display.
+    open func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return self.numberOfComponents
+    }
+    
+    /// returns the # of rows in each component.
     open func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return pickerSource.numberOfRows(in: component) + 1
+        return self.numberOfRows(inComponent: component)
     }
     
     // MARK: UIPickerViewDelegate
     
+    /// Returns the text value associated with the given row. If this is a separator, this will return the
+    /// `pickerSource.separator`. Otherwise, this method will return the choice text for the choice returned
+    /// by the picker.
     open func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        guard row > 0 else { return nil }
-        guard let choice = pickerSource.choice(forRow: row - 1, forComponent: component) else { return nil }
+        guard !isSeparatorComponent(component) else {
+            return hasSeparator ? pickerSource.separator : nil
+        }
+        guard let choice = choice(forRow: row, forComponent: component) else {
+            return nil
+        }
         return choice.text
     }
     
+    /// Return a view to use for this picker. By default, this method returns a label that is
+    /// alligned with the components center aligned.
+    open func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
+        let label = (view as? UILabel) ?? instantiateLabel(for: component)
+        label.text = self.pickerView(self, titleForRow: row, forComponent: component)
+        return label
+    }
+
+    /// Returns the width of the component. By default, the width is calculated based on the width
+    /// of the text.
+    open func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
+        guard let width = _rowWidth[component] else {
+            updateSize()
+            return _rowWidth[component] ?? 0
+        }
+        return width
+    }
+    
+    /// Returns the height for the row. By default, the height of the largest component is used for
+    /// all the components.
+    open func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
+        if _rowHeight == 0 { updateSize() }
+        return _rowHeight
+    }
+    
+    /// Let the observer know that the picker value has changed.
     open func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         self.observer?.pickerValueChanged(self)
     }
+
+    // MARK: Component view management
+    
+    /// Instantiate a label for the given component.
+    open func instantiateLabel(for component: Int) -> UILabel {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 24)
+        let isFirst = (component == 0)
+        let isLast = (component + 1 == numberOfComponents)
+        if numberOfComponents == 1 || !(isFirst || isLast) {
+            label.textAlignment = .center
+        } else {
+            label.textAlignment = isLast ? .right : .left
+        }
+        return label
+    }
+    
+    private func updateSize() {
+        guard pickerSource != nil else { return }
+        
+        let componentsCount = self.numberOfComponents
+        let maxSize = CGSize(width: Double.greatestFiniteMagnitude, height: Double.greatestFiniteMagnitude)
+        
+        for component in 0..<componentsCount {
+            
+            // Calculate the width and height
+            let label = self.instantiateLabel(for: component)
+            let font = label.font
+            let numRows = self.numberOfRows(inComponent: component)
+            var biggest = CGSize.zero
+            for row in 0..<numRows {
+                guard let text = self.pickerView(self, titleForRow: row, forComponent: component) else { continue }
+                let size = (text as NSString).boundingRect(with: maxSize, options: .usesLineFragmentOrigin, attributes: [.font : font as Any], context: nil)
+                biggest = CGSize(width: max(size.width, biggest.width), height: max(size.height, biggest.height))
+            }
+            
+            // Update the size constraints for each
+            let margins = label.layoutMargins
+            let widthMargins = isSeparatorComponent(component) ? 0 : margins.left + margins.right
+            _rowWidth[component] = ceil(biggest.width) + widthMargins
+            _rowHeight = max(_rowHeight, ceil(biggest.height) + margins.top + margins.bottom)
+        }
+    }
+    private var _rowWidth: [Int: CGFloat] = [:]
+    private var _rowHeight: CGFloat = 0
+    
 }
 
 /// `RSDNumberPickerView` is a `UIPickerView` that can be used to represent a picker with an associated index path.


### PR DESCRIPTION
This includes adding the `.duration` data type to the form data types *and* removing the `.timeInterval` from the base answer types. I removed the time interval data type b/c it can be described using a `.decimal` type and thus it was redundant. Adding the time interval type also highlighted the issue of the picker fields not properly displaying the separator string (if there is one) so I fixed that as well. 