### PR TITLE
Assorted refactoring to more easily support BridgeSDK and ResearchKit

### DIFF
--- a/ResearchSuite/ResearchSuite/RSDChoiceObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDChoiceObject.swift
@@ -41,7 +41,7 @@ public struct RSDChoiceObject<T : Codable> : RSDChoice, RSDComparable, RSDEmbedd
     public typealias Value = T
     
     /// A JSON encodable object to return as the value when this choice is selected.
-    public var value: Codable? {
+    public var answerValue: Codable? {
         return _value
     }
     private let _value: Value?

--- a/ResearchSuite/ResearchSuite/RSDChoiceOptionsObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDChoiceOptionsObject.swift
@@ -82,7 +82,7 @@ extension RSDChoiceOptions {
     /// - returns: The answer created from the given array of selected rows.
     public func selectedAnswer(with selectedRows: [Int]) -> Any? {
         guard selectedRows.count == 1, let row = selectedRows.first else { return nil }
-        return self.choice(forRow: row, forComponent: 0)?.value
+        return self.choice(forRow: row, forComponent: 0)?.answerValue
     }
     
     /// Returns the selected rows that match the given selected answer (if any).
@@ -90,7 +90,7 @@ extension RSDChoiceOptions {
     /// - returns: The selected rows, where there is a selected row for each component, or `nil` if not
     ///            all rows are selected.
     public func selectedRows(from selectedAnswer: Any?) -> [Int]? {
-        guard let index = self.choices.index(where: { RSDObjectEquality($0.value, selectedAnswer) }) else { return nil }
+        guard let index = self.choices.index(where: { RSDObjectEquality($0.answerValue, selectedAnswer) }) else { return nil }
         return [index]
     }
     

--- a/ResearchSuite/ResearchSuite/RSDChoicePickerTableItemGroup.swift
+++ b/ResearchSuite/ResearchSuite/RSDChoicePickerTableItemGroup.swift
@@ -112,10 +112,10 @@ open class RSDChoicePickerTableItemGroup : RSDInputFieldTableItemGroup {
         // our other items and de-select them.
         var answers: [Any] = []
         for (ii, input) in selectableItems.enumerated() {
-            if deselectOthers || (ii == index) || input.choice.isExclusive || (input.choice.value == nil) {
+            if deselectOthers || (ii == index) || input.choice.isExclusive || (input.choice.answerValue == nil) {
                 input.selected = (ii == index) && selected
             }
-            if input.selected, let value = input.choice.value {
+            if input.selected, let value = input.choice.answerValue {
                 answers.append(value)
             }
         }

--- a/ResearchSuite/ResearchSuite/RSDChoicePickerTableItemGroup.swift
+++ b/ResearchSuite/ResearchSuite/RSDChoicePickerTableItemGroup.swift
@@ -145,7 +145,7 @@ public final class RSDBooleanTableItemGroup : RSDChoicePickerTableItemGroup {
             self.singleCheckbox = (choicePicker.numberOfComponents == 1 && choicePicker.numberOfRows(in: 0) == 1)
         }
         else if uiHint == .checkbox || uiHint == .radioButton {
-            let text = inputField.prompt ?? Localization.buttonYes()
+            let text = inputField.inputPrompt ?? Localization.buttonYes()
             let choiceYes = try! RSDChoiceObject<Bool>(value: true, text: text, iconName: nil, detail: nil, isExclusive: true)
             choicePicker = RSDChoiceOptionsObject(choices: [choiceYes], isOptional: true)
             self.singleCheckbox = true

--- a/ResearchSuite/ResearchSuite/RSDChoiceTableItem.swift
+++ b/ResearchSuite/ResearchSuite/RSDChoiceTableItem.swift
@@ -41,7 +41,7 @@ open class RSDChoiceTableItem : RSDInputFieldTableItem {
     
     /// The answer associated with this choice
     open override var answer: Any? {
-        return selected ? choice.value : nil
+        return selected ? choice.answerValue : nil
     }
     
     /// Whether or not the choice is currently selected.

--- a/ResearchSuite/ResearchSuite/RSDDateCoderObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDDateCoderObject.swift
@@ -45,16 +45,13 @@ import Foundation
 public struct RSDDateCoderObject : RSDDateCoder, RawRepresentable {
 
     /// Coder for a timestamp.
-    public static let timestampCoder = RSDDateCoderObject(rawValue: "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ")!
+    public static let timestamp = RSDDateCoderObject(rawValue: "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ")!
     
     /// Coder for a date only.
-    public static let dateOnlyCoder = RSDDateCoderObject(rawValue: "yyyy-MM-dd")!
-    
-    /// Coder for a time only.
-    public static let timeOnlyCoder = RSDDateCoderObject(rawValue: "HH:mm:ss")!
+    public static let dateOnly = RSDDateCoderObject(rawValue: "yyyy-MM-dd")!
     
     /// Coder for a time of day.
-    public static let timeOfDayCoder = RSDDateCoderObject(rawValue: "HH:mm")!
+    public static let timeOfDay = RSDDateCoderObject(rawValue: "HH:mm:ss")!
     
     /// The input format used to represent the formatters and calendar components.
     public var rawValue: String {
@@ -172,6 +169,9 @@ public struct RSDDateCoderObject : RSDDateCoder, RawRepresentable {
         }
         return components
     }
+}
+
+extension RSDDateCoderObject : Equatable {
 }
 
 extension RSDDateCoderObject : RSDDocumentableEnum {

--- a/ResearchSuite/ResearchSuite/RSDDateRangeObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDDateRangeObject.swift
@@ -47,11 +47,11 @@ public struct RSDDateRangeObject : RSDDateRange, Codable {
     
     /// Whether or not the UI should allow future dates. If `nil` or if `maxDate` is defined then this value
     /// is ignored. Default is `true`.
-    public let allowFuture: Bool?
+    public let shouldAllowFuture: Bool?
     
     /// Whether or not the UI should allow past dates. If `nil` or if `minDate` is defined then this value
     /// is ignored. Default is `true`.
-    public let allowPast: Bool?
+    public let shouldAllowPast: Bool?
     
     /// The minute interval to allow for a time picker. A time picker will default to 1 minute if this
     /// is `nil` or if the number is outside the allowable range of 1 to 30 minutes.
@@ -73,8 +73,8 @@ public struct RSDDateRangeObject : RSDDateRange, Codable {
     public init(minimumDate: Date?, maximumDate: Date?, allowFuture: Bool? = nil, allowPast: Bool? = nil, minuteInterval: Int? = nil, dateCoder: RSDDateCoder? = nil) {
         self.minDate = minimumDate
         self.maxDate = maximumDate
-        self.allowFuture = allowFuture
-        self.allowPast = allowPast
+        self.shouldAllowFuture = allowFuture
+        self.shouldAllowPast = allowPast
         self.minuteInterval = minuteInterval
         self.dateCoder = dateCoder
     }
@@ -139,8 +139,8 @@ public struct RSDDateRangeObject : RSDDateRange, Codable {
         self.dateCoder = dateCoder
         self.minDate = minDate
         self.maxDate = maxDate
-        self.allowPast = try container.decodeIfPresent(Bool.self, forKey: .allowPast)
-        self.allowFuture = try container.decodeIfPresent(Bool.self, forKey: .allowFuture)
+        self.shouldAllowPast = try container.decodeIfPresent(Bool.self, forKey: .allowPast)
+        self.shouldAllowFuture = try container.decodeIfPresent(Bool.self, forKey: .allowFuture)
         self.minuteInterval = try container.decodeIfPresent(Int.self, forKey: .minuteInterval)
     }
     
@@ -163,8 +163,8 @@ public struct RSDDateRangeObject : RSDDateRange, Codable {
             try container.encodeIfPresent(minDate, forKey: .minDate)
             try container.encodeIfPresent(maxDate, forKey: .maxDate)
         }
-        try container.encodeIfPresent(allowPast, forKey: .allowPast)
-        try container.encodeIfPresent(allowFuture, forKey: .allowFuture)
+        try container.encodeIfPresent(shouldAllowPast, forKey: .allowPast)
+        try container.encodeIfPresent(shouldAllowFuture, forKey: .allowFuture)
         try container.encodeIfPresent(minuteInterval, forKey: .minuteInterval)
     }
 }

--- a/ResearchSuite/ResearchSuite/RSDDurationPickerDataSourceObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDDurationPickerDataSourceObject.swift
@@ -102,7 +102,7 @@ public struct RSDDurationPickerDataSourceObject : RSDMultipleComponentChoiceOpti
         let value: Double = selectedRows.enumerated().reduce(0) { (input, arg) -> Double in
             let (component, index) = arg
             let unit = self.componentUnits[component]
-            let choiceValue = self.componentChoices[component][index].value as! Int
+            let choiceValue = self.componentChoices[component][index].answerValue as! Int
             let measurement = Measurement(value: Double(choiceValue), unit: unit)
             return input + measurement.valueConverted(to: baseUnit)
         }
@@ -117,7 +117,7 @@ public struct RSDDurationPickerDataSourceObject : RSDMultipleComponentChoiceOpti
         guard let duration = duration(for: selectedAnswer) else { return nil }
         return componentUnits.enumerated().map { (idx, unit) -> Int in
             let value = duration.component(of: unit)
-            return self.componentChoices[idx].index(where: { ($0.value as! Int) == value }) ?? 0
+            return self.componentChoices[idx].index(where: { ($0.answerValue as! Int) == value }) ?? 0
         }
     }
     

--- a/ResearchSuite/ResearchSuite/RSDFormStepDataSourceObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDFormStepDataSourceObject.swift
@@ -257,7 +257,7 @@ open class RSDFormStepDataSourceObject : RSDFormStepDataSource {
             else {
                 let section = RSDTableSectionBuilder(sectionIndex: sectionBuilders.count, singleFormItem: needExclusiveSection)
                 section.itemGroups.append(itemGroup)
-                section.title = item.prompt
+                section.title = item.inputPrompt
                 sectionBuilders.append(section)
             }
         }

--- a/ResearchSuite/ResearchSuite/RSDFormStepDataSourceObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDFormStepDataSourceObject.swift
@@ -174,7 +174,7 @@ open class RSDFormStepDataSourceObject : RSDFormStepDataSource {
         if case .measurement(_,_) = inputField.dataType {
             return RSDHumanMeasurementTableItemGroup(beginningRowIndex: beginningRowIndex, inputField: inputField, uiHint: uiHint)
         }
-        else if let choiceInput = inputField as? RSDChoiceInputField {
+        else if let choiceInput = inputField.pickerSource as? RSDChoiceInputField {
             return RSDChoicePickerTableItemGroup(beginningRowIndex: beginningRowIndex, inputField: inputField, uiHint: uiHint, choicePicker: choiceInput)
         }
         else if let componentInput = inputField as? RSDMultipleComponentInputField {

--- a/ResearchSuite/ResearchSuite/RSDFormStepDataSourceObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDFormStepDataSourceObject.swift
@@ -131,7 +131,7 @@ open class RSDFormStepDataSourceObject : RSDFormStepDataSource {
     /// - parameter inputField  The inputField to check.
     /// - returns: The ui hint to return.
     open func preferredUIHint(for inputField: RSDInputField) -> RSDFormUIHint {
-        if let uiHint = inputField.uiHint, supportedHints.contains(uiHint) {
+        if let uiHint = inputField.inputUIHint, supportedHints.contains(uiHint) {
             return uiHint
         }
         let standardType: RSDFormUIHint?

--- a/ResearchSuite/ResearchSuite/RSDInputField.swift
+++ b/ResearchSuite/ResearchSuite/RSDInputField.swift
@@ -78,6 +78,9 @@ public protocol RSDInputField {
     /// - seealso: `RSDAnswerResultType.BaseType` and `RSDFormStepDataSource`
     var formatter: Formatter? { get }
     
+    /// Optional picker source for a picker or multiple selection input field.
+    var pickerSource: RSDPickerDataSource? { get }
+    
     /// Validate the input field to check for any configuration that should throw an error.
     func validate() throws
 }

--- a/ResearchSuite/ResearchSuite/RSDInputField.swift
+++ b/ResearchSuite/ResearchSuite/RSDInputField.swift
@@ -47,7 +47,7 @@ public protocol RSDInputField {
     
     /// A localized string that displays a short text offering a hint to the user of the data to be entered for
     /// this field.
-    var prompt: String? { get }
+    var inputPrompt: String? { get }
     
     /// A localized string that displays placeholder information for the input field.
     ///

--- a/ResearchSuite/ResearchSuite/RSDInputField.swift
+++ b/ResearchSuite/ResearchSuite/RSDInputField.swift
@@ -62,7 +62,7 @@ public protocol RSDInputField {
     var dataType: RSDFormDataType { get }
     
     /// A UI hint for how the study would prefer that the input field is displayed to the user.
-    var uiHint: RSDFormUIHint? { get }
+    var inputUIHint: RSDFormUIHint? { get }
     
     /// Options for displaying a text field. This is only applicable for certain types of UI hints and data types.
     var textFieldOptions: RSDTextFieldOptions? { get }

--- a/ResearchSuite/ResearchSuite/RSDInputField.swift
+++ b/ResearchSuite/ResearchSuite/RSDInputField.swift
@@ -90,7 +90,7 @@ public protocol RSDChoice {
     
     /// A JSON encodable object to return as the value when this choice is selected. A `nil` value indicates that
     /// the user has selected to skip the question or "prefers not to answer".
-    var value: Codable? { get }
+    var answerValue: Codable? { get }
     
     /// Localized text string to display for the choice.
     var text: String? { get }

--- a/ResearchSuite/ResearchSuite/RSDInputFieldObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDInputFieldObject.swift
@@ -50,7 +50,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
     
     /// A localized string that displays a short text offering a hint to the user of the data to be entered for
     /// this field. This is only applicable for certain types of UI hints and data types.
-    open var prompt: String?
+    open var inputPrompt: String?
     
     /// A localized string that displays placeholder information for the input field.
     ///
@@ -98,7 +98,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
         self.identifier = identifier
         self.dataType = dataType
         self.uiHint = uiHint
-        self.prompt = prompt
+        self.inputPrompt = prompt
     }
     
     /// Validate the input field to check for any configuration that should throw an error.
@@ -335,7 +335,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
         self.textFieldOptions = textFieldOptions
         self.surveyRules = surveyRules
         self.identifier = try container.decode(String.self, forKey: .identifier)
-        self.prompt = try container.decodeIfPresent(String.self, forKey: .prompt)
+        self.inputPrompt = try container.decodeIfPresent(String.self, forKey: .prompt)
         self.placeholder = try container.decodeIfPresent(String.self, forKey: .placeholder)
         self.isOptional = try container.decodeIfPresent(Bool.self, forKey: .isOptional) ?? false
     }
@@ -347,7 +347,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.identifier, forKey: .identifier)
         try container.encode(self.dataType, forKey: .dataType)
-        try container.encodeIfPresent(prompt, forKey: .prompt)
+        try container.encodeIfPresent(inputPrompt, forKey: .prompt)
         try container.encodeIfPresent(placeholder, forKey: .placeholder)
         try container.encodeIfPresent(uiHint, forKey: .uiHint)
         if let obj = self.range {

--- a/ResearchSuite/ResearchSuite/RSDInputFieldObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDInputFieldObject.swift
@@ -46,7 +46,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
     open private(set) var dataType: RSDFormDataType
     
     /// A UI hint for how the study would prefer that the input field is displayed to the user.
-    open private(set) var uiHint: RSDFormUIHint?
+    open private(set) var inputUIHint: RSDFormUIHint?
     
     /// A localized string that displays a short text offering a hint to the user of the data to be entered for
     /// this field. This is only applicable for certain types of UI hints and data types.
@@ -97,7 +97,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
     public init(identifier: String, dataType: RSDFormDataType, uiHint: RSDFormUIHint? = nil, prompt: String? = nil) {
         self.identifier = identifier
         self.dataType = dataType
-        self.uiHint = uiHint
+        self.inputUIHint = uiHint
         self.inputPrompt = prompt
     }
     
@@ -330,7 +330,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.dataType = dataType
-        self.uiHint = uiHint
+        self.inputUIHint = uiHint
         self.range = range
         self.textFieldOptions = textFieldOptions
         self.surveyRules = surveyRules
@@ -349,7 +349,7 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
         try container.encode(self.dataType, forKey: .dataType)
         try container.encodeIfPresent(inputPrompt, forKey: .prompt)
         try container.encodeIfPresent(placeholder, forKey: .placeholder)
-        try container.encodeIfPresent(uiHint, forKey: .uiHint)
+        try container.encodeIfPresent(inputUIHint, forKey: .uiHint)
         if let obj = self.range {
             let nestedEncoder = container.superEncoder(forKey: .range)
             guard let encodable = obj as? Encodable else {

--- a/ResearchSuite/ResearchSuite/RSDInputFieldObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDInputFieldObject.swift
@@ -86,6 +86,11 @@ open class RSDInputFieldObject : RSDSurveyInputField, Codable {
     }
     private var _formatter: Formatter?
     
+    /// Default for the picker source is to optionally cast self.
+    open var pickerSource: RSDPickerDataSource? {
+        return self as? RSDPickerDataSource
+    }
+    
     /// Default intializer.
     ///
     /// - parameters:

--- a/ResearchSuite/ResearchSuite/RSDInputFieldTableItemGroup.swift
+++ b/ResearchSuite/ResearchSuite/RSDInputFieldTableItemGroup.swift
@@ -152,7 +152,7 @@ public final class RSDDateTableItemGroup : RSDInputFieldTableItemGroup {
     ///     - uiHint: The UI hint.
     public init(beginningRowIndex: Int, inputField: RSDInputField, uiHint: RSDFormUIHint) {
         
-        var pickerSource: RSDPickerDataSource? = inputField as? RSDPickerDataSource
+        var pickerSource: RSDPickerDataSource? = inputField.pickerSource
         var formatter: Formatter? = (inputField.range as? RSDRangeWithFormatter)?.formatter
         var dateFormatter: DateFormatter?
         

--- a/ResearchSuite/ResearchSuite/RSDMeasurementInputTableItem.swift
+++ b/ResearchSuite/ResearchSuite/RSDMeasurementInputTableItem.swift
@@ -89,7 +89,7 @@ public final class RSDHeightInputTableItem : RSDTextInputTableItem {
         
         // If the measurement size is for an adult and the locale is US
         // then use a picker with feet/inches.
-        var pickerSource: RSDPickerDataSource? = (inputField as? RSDPickerDataSource)
+        var pickerSource: RSDPickerDataSource? = inputField.pickerSource
         if pickerSource == nil, measurementSize == .adult, !Locale.current.usesMetricSystem {
             pickerSource = RSDUSHeightPickerDataSourceObject(formatter: formatter as? RSDLengthFormatter)
         }
@@ -169,7 +169,7 @@ public final class RSDMassInputTableItem : RSDTextInputTableItem {
         
         // If the measurement is for an infant and the locale is US
         // then use the infant mass picker.
-        var pickerSource: RSDPickerDataSource? = (inputField as? RSDPickerDataSource)
+        var pickerSource: RSDPickerDataSource? = inputField.pickerSource
         if pickerSource == nil, measurementSize == .infant, !Locale.current.usesMetricSystem {
             pickerSource = RSDUSInfantMassPickerDataSourceObject(formatter: formatter as? RSDMassFormatter)
         }

--- a/ResearchSuite/ResearchSuite/RSDMultipleComponentOptionsObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDMultipleComponentOptionsObject.swift
@@ -94,7 +94,7 @@ extension RSDMultipleComponentOptions {
     /// - returns: The answer created from the given array of selected rows.
     public func selectedAnswer(with selectedRows: [Int]) -> Any? {
         let choices = selectedRows.enumerated().rsd_mapAndFilter { (component, selectedRow) -> Any? in
-            return self.choice(forRow: selectedRow, forComponent: component)?.value
+            return self.choice(forRow: selectedRow, forComponent: component)?.answerValue
         }
         guard choices.count == self.numberOfComponents
             else {
@@ -114,7 +114,7 @@ extension RSDMultipleComponentOptions {
         
         // Filter through and look for the current answer
         let selected: [Int] = answers.enumerated().rsd_mapAndFilter { (component, value) -> Int? in
-            return choices[component].index(where: { RSDObjectEquality($0.value, value) })
+            return choices[component].index(where: { RSDObjectEquality($0.answerValue, value) })
         }
         
         return selected.count == self.numberOfComponents ? selected : nil

--- a/ResearchSuite/ResearchSuite/RSDNumberInputTableItem.swift
+++ b/ResearchSuite/ResearchSuite/RSDNumberInputTableItem.swift
@@ -47,7 +47,7 @@ public final class RSDNumberInputTableItem : RSDTextInputTableItem {
     public init(rowIndex: Int, inputField: RSDInputField, uiHint: RSDFormUIHint) {
         
         var formatter: Formatter?
-        var pickerSource: RSDPickerDataSource? = inputField as? RSDPickerDataSource
+        var pickerSource: RSDPickerDataSource? = inputField.pickerSource
         var range: RSDNumberRange? = (inputField.range as? RSDNumberRange)
         var unitString: String? = range?.unit
         var textFieldOptions: RSDTextFieldOptions? = nil

--- a/ResearchSuite/ResearchSuite/RSDRange.swift
+++ b/ResearchSuite/ResearchSuite/RSDRange.swift
@@ -63,11 +63,11 @@ public protocol RSDDateRange : RSDRange {
     
     /// Whether or not the UI should allow future dates. If `nil` or if `minDate` is defined then this value
     /// is ignored. Default is `true`.
-    var allowFuture: Bool? { get }
+    var shouldAllowFuture: Bool? { get }
     
     /// Whether or not the UI should allow past dates. If `nil` or if `maxDate` is defined then this value
     /// is ignored. Default is `true`.
-    var allowPast: Bool? { get }
+    var shouldAllowPast: Bool? { get }
     
     /// The minute interval to allow for a time picker. A time picker will default to 1 minute if this
     /// is `nil` or if the number is outside the allowable range of 1 to 30 minutes.
@@ -84,14 +84,14 @@ extension RSDDateRange {
     /// date if `allowPast` is non-nil and `false`. If both `minDate` and `allowPast` are `nil` then this
     /// property will return `nil`.
     public var minimumDate: Date? {
-        return minDate ?? ((allowPast ?? true) ? nil : Date())
+        return minDate ?? ((shouldAllowPast ?? true) ? nil : Date())
     }
     
     /// The maximum allowed date. This is calculated by using either the `maxDate` (if non-nil) or today's
     /// date if `allowFuture` is non-nil and `false`. If both `maxDate` and `allowFuture` are `nil` then this
     /// property will return `nil`.
     public var maximumDate: Date? {
-        return maxDate ?? ((allowFuture ?? true) ? nil : Date())
+        return maxDate ?? ((shouldAllowFuture ?? true) ? nil : Date())
     }
 }
 

--- a/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableInputFieldObjectTests.swift
+++ b/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableInputFieldObjectTests.swift
@@ -228,7 +228,7 @@ class CodableInputFieldObjectTests: XCTestCase {
             let object = try decoder.decode(RSDChoiceInputFieldObject.self, from: json)
             
             XCTAssertEqual(object.identifier, "foo")
-            XCTAssertEqual(object.prompt, "Text")
+            XCTAssertEqual(object.inputPrompt, "Text")
             XCTAssertEqual(object.placeholder, "enter text")
             XCTAssertEqual(object.dataType, .collection(.singleChoice, .integer))
             XCTAssertEqual(object.uiHint, .picker)
@@ -289,7 +289,7 @@ class CodableInputFieldObjectTests: XCTestCase {
             let object = try decoder.decode(RSDChoiceInputFieldObject.self, from: json)
             
             XCTAssertEqual(object.identifier, "foo")
-            XCTAssertEqual(object.prompt, "Text")
+            XCTAssertEqual(object.inputPrompt, "Text")
             XCTAssertEqual(object.dataType, .collection(.singleChoice, .fraction))
             XCTAssertEqual(object.choices.count, 3)
             XCTAssertEqual(object.choices.last?.text, "1/125")

--- a/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableInputFieldObjectTests.swift
+++ b/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableInputFieldObjectTests.swift
@@ -231,7 +231,7 @@ class CodableInputFieldObjectTests: XCTestCase {
             XCTAssertEqual(object.inputPrompt, "Text")
             XCTAssertEqual(object.placeholder, "enter text")
             XCTAssertEqual(object.dataType, .collection(.singleChoice, .integer))
-            XCTAssertEqual(object.uiHint, .picker)
+            XCTAssertEqual(object.inputUIHint, .picker)
             XCTAssertTrue(object.isOptional)
             XCTAssertEqual(object.choices.count, 4)
             XCTAssertEqual(object.choices.last?.text, "always")
@@ -370,7 +370,7 @@ class CodableInputFieldObjectTests: XCTestCase {
             
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.dataType, .base(.integer))
-            XCTAssertEqual(object.uiHint, .slider)
+            XCTAssertEqual(object.inputUIHint, .slider)
             if let range = object.range as? RSDNumberRange {
                 XCTAssertEqual(range.minimumValue, -2)
                 XCTAssertEqual(range.maximumValue, 3)
@@ -459,7 +459,7 @@ class CodableInputFieldObjectTests: XCTestCase {
             
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.dataType, .base(.decimal))
-            XCTAssertEqual(object.uiHint, .slider)
+            XCTAssertEqual(object.inputUIHint, .slider)
             if let range = object.range as? RSDNumberRangeObject {
                 XCTAssertEqual(range.minimumValue, -2.5)
                 XCTAssertEqual(range.maximumValue, 3)
@@ -525,7 +525,7 @@ class CodableInputFieldObjectTests: XCTestCase {
             
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.dataType, .base(.duration))
-            XCTAssertEqual(object.uiHint, .picker)
+            XCTAssertEqual(object.inputUIHint, .picker)
             if let range = object.range as? RSDDurationRangeObject {
                 XCTAssertEqual(range.baseUnit, .minutes)
                 XCTAssertEqual(range.minimumDuration, Measurement(value: 15, unit: UnitDuration.minutes))
@@ -590,7 +590,7 @@ class CodableInputFieldObjectTests: XCTestCase {
             
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.dataType, .base(.date))
-            XCTAssertEqual(object.uiHint, .picker)
+            XCTAssertEqual(object.inputUIHint, .picker)
             if let range = object.range as? RSDDateRange {
                 
                 let calendar = Calendar(identifier: .gregorian)
@@ -666,7 +666,7 @@ class CodableInputFieldObjectTests: XCTestCase {
             
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.dataType, .base(.string))
-            XCTAssertEqual(object.uiHint, .textfield)
+            XCTAssertEqual(object.inputUIHint, .textfield)
             if let textFieldOptions = object.textFieldOptions  {
                 XCTAssertEqual((textFieldOptions.textValidator as? RSDRegExValidatorObject)?.regExPattern, "[A:C]")
                 XCTAssertEqual(textFieldOptions.invalidMessage, "You know me")
@@ -724,7 +724,7 @@ class CodableInputFieldObjectTests: XCTestCase {
             
             XCTAssertEqual(object.identifier, "foo")
             XCTAssertEqual(object.dataType, .base(.string))
-            XCTAssertEqual(object.uiHint, .textfield)
+            XCTAssertEqual(object.inputUIHint, .textfield)
             if let textFieldOptions = object.textFieldOptions  {
                 XCTAssertNil(textFieldOptions.textValidator)
                 XCTAssertNil(textFieldOptions.invalidMessage)

--- a/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableInputFieldObjectTests.swift
+++ b/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableInputFieldObjectTests.swift
@@ -64,7 +64,7 @@ class CodableInputFieldObjectTests: XCTestCase {
             
             let object = try decoder.decode(RSDChoiceObject<String>.self, from: json)
             
-            XCTAssertEqual(object.value as? String, "foo")
+            XCTAssertEqual(object.answerValue as? String, "foo")
             XCTAssertEqual(object.text, "Some text.")
             XCTAssertEqual(object.detail, "A detail about the object")
             XCTAssertEqual(object.icon?.imageName, "fooImage")
@@ -104,7 +104,7 @@ class CodableInputFieldObjectTests: XCTestCase {
         do {
             let object = try decoder.decode(RSDChoiceObject<Int>.self, from: json)
             
-            XCTAssertEqual(object.value as? Int, 3)
+            XCTAssertEqual(object.answerValue as? Int, 3)
             XCTAssertEqual(object.text, "Some text.")
             XCTAssertEqual(object.detail, "A detail about the object")
             XCTAssertEqual(object.icon?.imageName, "fooImage")
@@ -139,8 +139,8 @@ class CodableInputFieldObjectTests: XCTestCase {
             let objects = try decoder.decode([RSDChoiceObject<String>].self, from: json)
             
             XCTAssertEqual(objects.count, 2)
-            XCTAssertEqual(objects.first?.value as? String, "alpha")
-            XCTAssertEqual(objects.last?.value as? String, "beta")
+            XCTAssertEqual(objects.first?.answerValue as? String, "alpha")
+            XCTAssertEqual(objects.last?.answerValue as? String, "beta")
             
             guard let object = objects.first else {
                 return
@@ -181,7 +181,7 @@ class CodableInputFieldObjectTests: XCTestCase {
             XCTAssertFalse(object.isOptional)
             XCTAssertEqual(object.choices.count, 4)
             XCTAssertEqual(object.choices.last?.text, "always")
-            XCTAssertEqual(object.choices.last?.value as? String, "always")
+            XCTAssertEqual(object.choices.last?.answerValue as? String, "always")
             
             let jsonData = try encoder.encode(object)
             guard let dictionary = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String : Any]
@@ -235,7 +235,7 @@ class CodableInputFieldObjectTests: XCTestCase {
             XCTAssertTrue(object.isOptional)
             XCTAssertEqual(object.choices.count, 4)
             XCTAssertEqual(object.choices.last?.text, "always")
-            XCTAssertEqual(object.choices.last?.value as? Int, 3)
+            XCTAssertEqual(object.choices.last?.answerValue as? Int, 3)
             
             if let surveyRules = object.surveyRules, let rule = surveyRules.first as? RSDComparableSurveyRule {
                 XCTAssertNil(rule.skipToIdentifier)
@@ -293,7 +293,7 @@ class CodableInputFieldObjectTests: XCTestCase {
             XCTAssertEqual(object.dataType, .collection(.singleChoice, .fraction))
             XCTAssertEqual(object.choices.count, 3)
             XCTAssertEqual(object.choices.last?.text, "1/125")
-            XCTAssertEqual((object.choices.last?.value as? RSDFraction)?.doubleValue, 1.0 / 125.0)
+            XCTAssertEqual((object.choices.last?.answerValue as? RSDFraction)?.doubleValue, 1.0 / 125.0)
             
         } catch let err {
             XCTFail("Failed to decode/encode object: \(err)")

--- a/ResearchSuite/ResearchSuiteTests/DataSource Tests/PickerDataSourceTests.swift
+++ b/ResearchSuite/ResearchSuiteTests/DataSource Tests/PickerDataSourceTests.swift
@@ -205,13 +205,13 @@ class PickerDataSourceTests: XCTestCase {
         
         // minute field
         XCTAssertEqual(picker.numberOfRows(in: 0), 61)
-        XCTAssertEqual(picker.componentChoices[0].first?.value as? Int, 0)
-        XCTAssertEqual(picker.componentChoices[0].last?.value as? Int, 60)
+        XCTAssertEqual(picker.componentChoices[0].first?.answerValue as? Int, 0)
+        XCTAssertEqual(picker.componentChoices[0].last?.answerValue as? Int, 60)
 
         // second field
         XCTAssertEqual(picker.numberOfRows(in: 1), 60)
-        XCTAssertEqual(picker.componentChoices[1].first?.value as? Int, 0)
-        XCTAssertEqual(picker.componentChoices[1].last?.value as? Int, 59)
+        XCTAssertEqual(picker.componentChoices[1].first?.answerValue as? Int, 0)
+        XCTAssertEqual(picker.componentChoices[1].last?.answerValue as? Int, 59)
         
         let inputAnswer = Double(90)
         let expectedRows = [1, 30]
@@ -222,8 +222,8 @@ class PickerDataSourceTests: XCTestCase {
         if let rows = picker.selectedRows(from: inputAnswer) {
             XCTAssertEqual(rows, expectedRows)
             if rows.count == 2 {
-                XCTAssertEqual(picker.choice(forRow: rows[0], forComponent: 0)?.value as? Int, expectedMinutes)
-                XCTAssertEqual(picker.choice(forRow: rows[1], forComponent: 1)?.value as? Int, expectedSeconds)
+                XCTAssertEqual(picker.choice(forRow: rows[0], forComponent: 0)?.answerValue as? Int, expectedMinutes)
+                XCTAssertEqual(picker.choice(forRow: rows[1], forComponent: 1)?.answerValue as? Int, expectedSeconds)
             } else {
                 XCTFail("Row count does not match expected. \(rows)")
             }
@@ -256,13 +256,13 @@ class PickerDataSourceTests: XCTestCase {
         
         // hour field
         XCTAssertEqual(picker.numberOfRows(in: 0), 25)
-        XCTAssertEqual(picker.componentChoices[0].first?.value as? Int, 0)
-        XCTAssertEqual(picker.componentChoices[0].last?.value as? Int, 24)
+        XCTAssertEqual(picker.componentChoices[0].first?.answerValue as? Int, 0)
+        XCTAssertEqual(picker.componentChoices[0].last?.answerValue as? Int, 24)
         
         // minute field
         XCTAssertEqual(picker.numberOfRows(in: 1), 60)
-        XCTAssertEqual(picker.componentChoices[1].first?.value as? Int, 0)
-        XCTAssertEqual(picker.componentChoices[1].last?.value as? Int, 59)
+        XCTAssertEqual(picker.componentChoices[1].first?.answerValue as? Int, 0)
+        XCTAssertEqual(picker.componentChoices[1].last?.answerValue as? Int, 59)
         
         let inputAnswer = Double(90)
         let expectedRows = [1, 30]
@@ -273,8 +273,8 @@ class PickerDataSourceTests: XCTestCase {
         if let rows = picker.selectedRows(from: inputAnswer) {
             XCTAssertEqual(rows, expectedRows)
             if rows.count == 2 {
-                XCTAssertEqual(picker.choice(forRow: rows[0], forComponent: 0)?.value as? Int, expectedHours)
-                XCTAssertEqual(picker.choice(forRow: rows[1], forComponent: 1)?.value as? Int, expectedMinutes)
+                XCTAssertEqual(picker.choice(forRow: rows[0], forComponent: 0)?.answerValue as? Int, expectedHours)
+                XCTAssertEqual(picker.choice(forRow: rows[1], forComponent: 1)?.answerValue as? Int, expectedMinutes)
             } else {
                 XCTFail("Row count does not match expected. \(rows)")
             }

--- a/ResearchSuiteUI/ResearchSuiteUI/iOS/Step View Controllers/RSDTableStepViewController.swift
+++ b/ResearchSuiteUI/ResearchSuiteUI/iOS/Step View Controllers/RSDTableStepViewController.swift
@@ -581,7 +581,7 @@ open class RSDTableStepViewController: RSDStepViewController, UITableViewDataSou
         }
         
         // populate the field label
-        textFieldCell.fieldLabel.text = tableItem.inputField.prompt
+        textFieldCell.fieldLabel.text = tableItem.inputField.inputPrompt
         
         // populate the text field placeholder label
         textFieldCell.placeholder = tableItem.placeholder


### PR DESCRIPTION
I changed the names to keep the BridgeSDK and ResearchKit properties from conflicting with the ResearchSuite protocol names for cases where the types aren't compatible and are not directly bridged from obj-c to swift.