### PR TITLE
Add tracking management for handling cohorts (data groups).

### DIFF
--- a/ResearchSuite/ResearchSuite.xcodeproj/project.pbxproj
+++ b/ResearchSuite/ResearchSuite.xcodeproj/project.pbxproj
@@ -143,6 +143,9 @@
 		F8F561E92023C2A9000EEA8C /* RSDDurationPickerDataSourceObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8321EB7201AB7F900074DFA /* RSDDurationPickerDataSourceObject.swift */; };
 		F8F72401203BF7BD00AC0E5B /* AnyObjectSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F72400203BF7BD00AC0E5B /* AnyObjectSerializationTests.swift */; };
 		F8F72402203BF7BD00AC0E5B /* AnyObjectSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F72400203BF7BD00AC0E5B /* AnyObjectSerializationTests.swift */; };
+		F8F72435203DF20E00AC0E5B /* RSDCohortTrackingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F72434203DF20E00AC0E5B /* RSDCohortTrackingRule.swift */; };
+		F8F72436203DF20E00AC0E5B /* RSDCohortTrackingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F72434203DF20E00AC0E5B /* RSDCohortTrackingRule.swift */; };
+		F8F72437203DF20E00AC0E5B /* RSDCohortTrackingRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F72434203DF20E00AC0E5B /* RSDCohortTrackingRule.swift */; };
 		F8F9544220239E8F00347940 /* RSDDateRangeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F9544120239E8F00347940 /* RSDDateRangeObject.swift */; };
 		F8F9544320239E8F00347940 /* RSDDateRangeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F9544120239E8F00347940 /* RSDDateRangeObject.swift */; };
 		F8F9544420239E8F00347940 /* RSDDateRangeObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F9544120239E8F00347940 /* RSDDateRangeObject.swift */; };
@@ -526,6 +529,7 @@
 		F8B17860202E22CC00B62416 /* RSDStandardAsyncActionConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RSDStandardAsyncActionConfiguration.swift; sourceTree = "<group>"; };
 		F8B42BE21FE9ABE200E23783 /* Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Localization.swift; sourceTree = "<group>"; };
 		F8F72400203BF7BD00AC0E5B /* AnyObjectSerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyObjectSerializationTests.swift; sourceTree = "<group>"; };
+		F8F72434203DF20E00AC0E5B /* RSDCohortTrackingRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDCohortTrackingRule.swift; sourceTree = "<group>"; };
 		F8F9544120239E8F00347940 /* RSDDateRangeObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDDateRangeObject.swift; sourceTree = "<group>"; };
 		F8F9544520239ED400347940 /* RSDNumberRangeObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDNumberRangeObject.swift; sourceTree = "<group>"; };
 		FF0920BE1FCE310500C9E031 /* RSDTableSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDTableSection.swift; sourceTree = "<group>"; };
@@ -779,6 +783,14 @@
 				F89BEA2F202B9550007BD2DD /* StepTests.swift */,
 			);
 			path = "ModelObject Tests";
+			sourceTree = "<group>";
+		};
+		F8F72433203DF1CD00AC0E5B /* Tracking */ = {
+			isa = PBXGroup;
+			children = (
+				F8F72434203DF20E00AC0E5B /* RSDCohortTrackingRule.swift */,
+			);
+			name = Tracking;
 			sourceTree = "<group>";
 		};
 		F8F9544020239E5D00347940 /* Range */ = {
@@ -1119,6 +1131,7 @@
 		FFF53EA81FBF9018004211D2 /* Objects */ = {
 			isa = PBXGroup;
 			children = (
+				F8F72433203DF1CD00AC0E5B /* Tracking */,
 				FFF53EA91FBF90AC004211D2 /* Common */,
 				FFB015CD1F8BF0A900AC209B /* AsyncAction */,
 				FF5C4C301F8C9D9600F311BA /* Result */,
@@ -1488,6 +1501,7 @@
 				F80CA5301FFEBE3200E89C06 /* RSDMeasurementInputTableItem.swift in Sources */,
 				FF8B53A81FCE6C7A006B6937 /* RSDResult.swift in Sources */,
 				FF8B53821FCE6C6F006B6937 /* RSDFormUIHint.swift in Sources */,
+				F8F72435203DF20E00AC0E5B /* RSDCohortTrackingRule.swift in Sources */,
 				FF8B54241FCE6CA2006B6937 /* RSDFormUIStepObject.swift in Sources */,
 				FF8B53B01FCE6C7A006B6937 /* RSDTask.swift in Sources */,
 				FF8B54951FCE6CEC006B6937 /* RSDTaskDataSource.swift in Sources */,
@@ -1683,6 +1697,7 @@
 				F8B42BE41FE9ABE200E23783 /* Localization.swift in Sources */,
 				F8A5E1611FFD6E5700D337A5 /* RSDMeasurementWrapper.m in Sources */,
 				FF8B54441FCE6CAA006B6937 /* RSDComparableSurveyRuleObject.swift in Sources */,
+				F8F72436203DF20E00AC0E5B /* RSDCohortTrackingRule.swift in Sources */,
 				FF8B54161FCE6C99006B6937 /* RSDResultObject.swift in Sources */,
 				FF8B53FC1FCE6C87006B6937 /* RSDRegExValidatorObject.swift in Sources */,
 				FF8B53CB1FCE6C7B006B6937 /* RSDUIThemeElement.swift in Sources */,
@@ -1810,6 +1825,7 @@
 				F8F9544420239E8F00347940 /* RSDDateRangeObject.swift in Sources */,
 				F80CA5321FFEBE3200E89C06 /* RSDMeasurementInputTableItem.swift in Sources */,
 				FF8B54191FCE6C9A006B6937 /* RSDAnswerResultObject.swift in Sources */,
+				F8F72437203DF20E00AC0E5B /* RSDCohortTrackingRule.swift in Sources */,
 				F829F0E81FF8AF28001B0680 /* NSUnit+RSDUnitConversion.m in Sources */,
 				FF8B544B1FCE6CAA006B6937 /* RSDComparableSurveyRuleObject.swift in Sources */,
 				FF8B541B1FCE6C9A006B6937 /* RSDResultObject.swift in Sources */,

--- a/ResearchSuite/ResearchSuite/RSDCohortTrackingRule.swift
+++ b/ResearchSuite/ResearchSuite/RSDCohortTrackingRule.swift
@@ -1,0 +1,230 @@
+//
+//  RSDCohortTrackingRule.swift
+//  ResearchSuite
+//
+//  Copyright © 2018 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import Foundation
+
+/// `RSDCohortAssignmentStep` evaluates a task result and returns the cohorts to apply for a given
+/// result.
+public protocol RSDCohortAssignmentStep : RSDStep {
+    
+    /// Evaluate the task result and return the set of cohorts to add and remove.
+    /// - parameter result: The task result to evaluate.
+    /// - returns: The cohorts to add/remove or `nil` if no rules apply.
+    func cohortsToApply(with result: RSDTaskResult) -> (add: Set<String>, remove: Set<String>)?
+}
+
+/// List of the rules to apply when navigating based on the currently applied cohorts.
+public enum RSDCohortRuleOperator : String, Codable {
+    /// Require all the cohorts to match.
+    case all
+    /// Require any of the cohorts to match.
+    case any
+}
+
+/// A cohort navigation rule is used by the `RSDCohortTrackingRule` to determine if a step should either
+/// be skipped or skip to a step based on the currently applied cohorts.
+public protocol RSDCohortNavigationRule {
+    
+    /// The list of cohorts that are tested for this navigation rule.
+    var requiredCohorts : Set<String> { get }
+    
+    /// What type of operator to apply. If `nil`, then `.all` is assumed.
+    var cohortOperator : RSDCohortRuleOperator? { get }
+    
+    /// Optional skip identifier for this rule.
+    ///
+    /// If this rule is applied *after* displaying the step, then this will be used as the identifier to
+    /// skip to. If `nil` then the skip to identifier will be assumed to be `RSDIdentifier.exit`.
+    ///
+    /// If this rule is applied *before* displaying the step, then this is the identifier to skip to. If
+    /// `nil` then just this step will be skipped.
+    var skipToIdentifier : String? { get }
+}
+
+/// A cohort navigation step is a step that carries information about navigation rules to apply either
+/// before or after displaying this step based on the currently applied cohorts.
+public protocol RSDCohortNavigationStep : RSDStep {
+    
+    /// The navigation cohort rules to apply *before* displaying the step.
+    var beforeCohortRules : [RSDCohortNavigationRule]? { get }
+    
+    /// The navigation cohort rules to apply *after* displaying the step.
+    var afterCohortRules : [RSDCohortNavigationRule]? { get }
+}
+
+/// A cohort rule can be used to mutate a list of cohorts of which the participant is a member. A cohort
+/// is a data group that participants are added to based on the results of survey questions.
+open class RSDCohortTrackingRule : RSDTrackingRule, Codable {
+
+    /// The initial cohorts before the task starts.
+    public let initialCohorts : Set<String>
+    
+    /// The current set of cohorts.
+    open private(set) var currentCohorts : Set<String>
+    
+    public init(initialCohorts : Set<String> = []) {
+        self.initialCohorts = initialCohorts
+        self.currentCohorts = initialCohorts
+    }
+    
+    /// MARK: RSDConditionalRule
+    
+    /// Check if the step implements `RSDCohortNavigationStep` and apply the before rules for the step to
+    /// the current cohorts.
+    public func skipToStepIdentifier(before step: RSDStep, with result: RSDTaskResult?, isPeeking: Bool) -> String? {
+        guard let cohortStep = step as? RSDCohortNavigationStep, let rules = cohortStep.beforeCohortRules else { return nil }
+        return applyRules(rules, isBefore: true)
+    }
+    
+    /// This method is used to test whether or not to mutate the current cohorts. This will look to see
+    /// if the step implements the `RSDCohortAssignmentStep` and if so, apply the new cohorts.
+    ///
+    /// Then it will check if the step implements `RSDCohortNavigationStep` and apply the after rules for
+    /// the step to the current cohorts.
+    open func nextStepIdentifier(after step: RSDStep?, with result: RSDTaskResult?, isPeeking: Bool) -> String? {
+        guard !isPeeking else { return nil }
+        
+        // Add and remove the subset of new cohorts.
+        if let taskResult = result,
+            let cohortStep = step as? RSDCohortAssignmentStep,
+            let cohorts = cohortStep.cohortsToApply(with: taskResult) {
+            self.currentCohorts.formUnion(cohorts.add)
+            self.currentCohorts.subtract(cohorts.remove)
+        }
+        
+        guard let cohortStep = step as? RSDCohortNavigationStep, let rules = cohortStep.afterCohortRules else { return nil }
+        return applyRules(rules, isBefore: false)
+    }
+    
+    func applyRules(_ rules: [RSDCohortNavigationRule], isBefore: Bool) -> String? {
+        for rule in rules {
+            // Special-case an empty set for the required cohorts. Rule should not be applied if there
+            // are no cohorts to test against.
+            guard rule.requiredCohorts.count > 0 else { continue }
+            
+            // Test the rule for whether or not it should be applied.
+            let op = rule.cohortOperator ?? .all
+            let shouldSkip: Bool = {
+                let intersect = self.currentCohorts.intersection(rule.requiredCohorts)
+                switch op {
+                case .all:
+                    return intersect == rule.requiredCohorts
+                case .any:
+                    return intersect.count > 0
+                }
+            }()
+            
+            // If applicable, then skip to the appropriate next step. The default behavior for this
+            // depends upon whether or not the rule is applied before or after displaying the step.
+            if shouldSkip {
+                return rule.skipToIdentifier ?? (isBefore ? RSDIdentifier.nextStep.stringValue : RSDIdentifier.nextSection.stringValue)
+            }
+        }
+        return nil
+    }
+}
+
+/// Concrete implementation of the `RSDCohortNavigationRule`.
+public struct RSDCohortNavigationRuleObject : RSDCohortNavigationRule, Codable {
+    
+    /// The list of cohorts that are tested for this navigation rule.
+    public let requiredCohorts: Set<String>
+    
+    /// What type of operator to apply.
+    public let cohortOperator: RSDCohortRuleOperator?
+    
+    /// The identifier for the string to skip to.
+    public let skipToIdentifier: String?
+    
+    private enum CodingKeys : String, CodingKey {
+        case requiredCohorts, cohortOperator = "operator", skipToIdentifier
+    }
+    
+    /// Default initializer.
+    /// - parameters:
+    ///     - requiredCohorts: The list of cohorts that are tested for this navigation rule.
+    ///     - cohortOperator: What type of operator to apply.
+    ///     - skipToIdentifier: The identifier for the string to skip to.
+    public init(requiredCohorts: Set<String>, cohortOperator: RSDCohortRuleOperator?, skipToIdentifier: String?) {
+        self.requiredCohorts = requiredCohorts
+        self.cohortOperator = cohortOperator
+        self.skipToIdentifier = skipToIdentifier
+    }
+}
+
+
+// Documentable implementations
+
+extension RSDCohortRuleOperator : RSDDocumentableEnum {
+    static func allCodingKeys() -> [String] {
+        let allKeys: [RSDCohortRuleOperator] = [.all, .any]
+        return allKeys.map { $0.stringValue }
+    }
+}
+
+extension RSDCohortNavigationRuleObject : RSDDocumentableCodableObject {
+    
+    static func codingKeys() -> [CodingKey] {
+        return allCodingKeys()
+    }
+    
+    private static func allCodingKeys() -> [CodingKeys] {
+        let codingKeys: [CodingKeys] = [.requiredCohorts, .cohortOperator, .skipToIdentifier]
+        return codingKeys
+    }
+    
+    static func validateAllKeysIncluded() -> Bool {
+        let keys: [CodingKeys] = allCodingKeys()
+        for (idx, key) in keys.enumerated() {
+            switch key {
+            case .requiredCohorts:
+                if idx != 0 { return false }
+            case .cohortOperator:
+                if idx != 1 { return false }
+            case .skipToIdentifier:
+                if idx != 2 { return false }
+            }
+        }
+        return keys.count == 3
+    }
+    
+    static func _examples() -> [RSDCohortNavigationRuleObject] {
+        let exampleA = RSDCohortNavigationRuleObject(requiredCohorts: ["foo", "goo"], cohortOperator: nil, skipToIdentifier: nil)
+        let exampleB = RSDCohortNavigationRuleObject(requiredCohorts: ["blue", "moo"], cohortOperator: .any, skipToIdentifier: "magoo")
+        return [exampleA, exampleB]
+    }
+    
+    static func examples() -> [Encodable] {
+        return _examples()
+    }
+}

--- a/ResearchSuite/ResearchSuite/RSDComparableSurveyRuleObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDComparableSurveyRuleObject.swift
@@ -42,6 +42,10 @@ public struct RSDComparableSurveyRuleObject<T : Codable> : RSDComparableSurveyRu
     /// otherwise the `skipToIdentifier` will be assumed to be `RSDIdentifier.exit`
     public let skipToIdentifier: String?
     
+    /// Optional cohort to assign if the rule matches. If available, then an `RSDCohortRule` can be used to track
+    /// the cohort to assign depending upon how this rule evaluates.
+    public let cohort: String?
+    
     /// The rule operator to apply. If `nil`, `.equal` will be assumed unless the `expectedAnswer` is also nil,
     /// in which case `.skip` will be assumed.
     public let ruleOperator: RSDSurveyRuleOperator?
@@ -60,14 +64,16 @@ public struct RSDComparableSurveyRuleObject<T : Codable> : RSDComparableSurveyRu
     ///     - skipToIdentifier: Skip identifier for this rule.
     ///     - matchingValue: Value-typed matching answer.
     ///     - ruleOperator: The rule operator to apply.
-    public init(skipToIdentifier: String?, matchingValue: Value?, ruleOperator: RSDSurveyRuleOperator?) {
+    ///     - cohort: The cohort to assign for this rule if it matches.
+    public init(skipToIdentifier: String?, matchingValue: Value?, ruleOperator: RSDSurveyRuleOperator?, cohort: String? = nil) {
         self.skipToIdentifier = skipToIdentifier
         self.matchingValue = matchingValue
         self.ruleOperator = ruleOperator
+        self.cohort = cohort
     }
     
     private enum CodingKeys: String, CodingKey {
-        case skipToIdentifier, matchingValue = "matchingAnswer", ruleOperator
+        case skipToIdentifier, matchingValue = "matchingAnswer", ruleOperator, cohort
     }
     
     /// Initialize from a `Decoder`. This method will decode the values and also check that the combination of
@@ -80,7 +86,8 @@ public struct RSDComparableSurveyRuleObject<T : Codable> : RSDComparableSurveyRu
         let skipToIdentifier = try container.decodeIfPresent(String.self, forKey: .skipToIdentifier)
         let matchingValue = try container.decodeIfPresent(Value.self, forKey: .matchingValue)
         let ruleOperator = try container.decodeIfPresent(RSDSurveyRuleOperator.self, forKey: .ruleOperator)
-        if (skipToIdentifier == nil) && (matchingValue == nil) && (ruleOperator == nil) {
+        let cohort = try container.decodeIfPresent(String.self, forKey: .cohort)
+        if (skipToIdentifier == nil) && (matchingValue == nil) && (ruleOperator == nil) && (cohort == nil) {
             let context = DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "All the values are nil. While each value in the comparable rule is optional, a comparable rule that does not include *any* values is invalid.")
             throw DecodingError.valueNotFound(Value.self, context)
         }
@@ -91,6 +98,7 @@ public struct RSDComparableSurveyRuleObject<T : Codable> : RSDComparableSurveyRu
         self.skipToIdentifier = skipToIdentifier
         self.matchingValue = matchingValue
         self.ruleOperator = ruleOperator
+        self.cohort = cohort
     }
 }
 
@@ -101,7 +109,7 @@ extension RSDComparableSurveyRuleObject : RSDDocumentableDecodableObject {
     }
     
     private static func allCodingKeys() -> [CodingKeys] {
-        let codingKeys: [CodingKeys] = [.skipToIdentifier, .matchingValue, .ruleOperator]
+        let codingKeys: [CodingKeys] = [.skipToIdentifier, .matchingValue, .ruleOperator, .cohort]
         return codingKeys
     }
     
@@ -115,9 +123,11 @@ extension RSDComparableSurveyRuleObject : RSDDocumentableDecodableObject {
                 if idx != 1 { return false }
             case .ruleOperator:
                 if idx != 2 { return false }
+            case .cohort:
+                if idx != 3 { return false }
             }
         }
-        return keys.count == 3
+        return keys.count == 4
     }
     
     static func examples() -> [[String : RSDJSONValue]] {

--- a/ResearchSuite/ResearchSuite/RSDDocumentable.swift
+++ b/ResearchSuite/ResearchSuite/RSDDocumentable.swift
@@ -2,7 +2,7 @@
 //  RSDDocumentable.swift
 //  ResearchSuite
 //
-//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//  Copyright © 2017-2018 Sage Bionetworks. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -48,6 +48,7 @@ public struct RSDDocumentCreator {
         RSDAnswerResultType.BaseType.self,
         RSDAnswerResultType.SequenceType.self,
         RSDAsyncActionType.self,
+        RSDCohortRuleOperator.self,
         RSDDateCoderObject.self,
         RSDDeviceType.self,
         RSDFormDataType.self,
@@ -85,25 +86,26 @@ public struct RSDDocumentCreator {
 
     let allCodableObjects: [RSDDocumentableCodableObject.Type] = {
         var allCodableObjects: [RSDDocumentableCodableObject.Type] = [
-            RSDAnswerResultType.self,
-            RSDResourceTransformerObject.self,
-            RSDStandardAsyncActionConfiguration.self,
-            RSDResultObject.self,
-            RSDAnswerResultObject.self,
-            RSDFileResultObject.self,
-            RSDCollectionResultObject.self,
-            RSDTaskResultObject.self,
-            RSDColorThemeElementObject.self,
-            RSDFetchableImageThemeElementObject.self,
             RSDAnimatedImageThemeElementObject.self,
-            RSDViewThemeElementObject.self,
-            RSDUIActionObject.self,
-            RSDSkipToUIActionObject.self,
-            RSDWebViewUIActionObject.self,
+            RSDAnswerResultObject.self,
+            RSDAnswerResultType.self,
+            RSDCohortNavigationRuleObject.self,
+            RSDCollectionResultObject.self,
+            RSDColorThemeElementObject.self,
             RSDDateRangeObject.self,
-            RSDNumberRangeObject.self,
-            RSDTextFieldOptionsObject.self,
             RSDDurationRangeObject.self,
+            RSDFetchableImageThemeElementObject.self,
+            RSDFileResultObject.self,
+            RSDNumberRangeObject.self,
+            RSDResourceTransformerObject.self,
+            RSDResultObject.self,
+            RSDSkipToUIActionObject.self,
+            RSDStandardAsyncActionConfiguration.self,
+            RSDTaskResultObject.self,
+            RSDTextFieldOptionsObject.self,
+            RSDUIActionObject.self,
+            RSDViewThemeElementObject.self,
+            RSDWebViewUIActionObject.self,
             ]
         
     #if os(iOS)

--- a/ResearchSuite/ResearchSuite/RSDFactory.swift
+++ b/ResearchSuite/ResearchSuite/RSDFactory.swift
@@ -61,6 +61,9 @@ open class RSDFactory {
     
     /// Optional data source for this factory.
     public var taskDataSource: RSDTaskDataSource?
+    
+    /// Optional shared tracking rules
+    open var trackingRules: [RSDTrackingRule] = []
 
     // MARK: Class name factory
     

--- a/ResearchSuite/ResearchSuite/RSDFormUIStepObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDFormUIStepObject.swift
@@ -2,7 +2,7 @@
 //  RSDFormUIStepObject.swift
 //  ResearchSuite
 //
-//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//  Copyright © 2017-2018 Sage Bionetworks. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:
@@ -33,9 +33,10 @@
 
 import Foundation
 
-/// `RSDFormUIStepObject` is a concrete implementation of the `RSDFormUIStep` and `RSDSurveyNavigationStep`
-/// protocols. It is a subclass of `RSDUIStepObject` and can be used to display a navigable survey.
-open class RSDFormUIStepObject : RSDUIStepObject, RSDFormUIStep, RSDSurveyNavigationStep {
+/// `RSDFormUIStepObject` is a concrete implementation of the `RSDFormUIStep` and
+/// `RSDSurveyNavigationStep` protocols. It is a subclass of `RSDUIStepObject` and can be used to display
+/// a navigable survey.
+open class RSDFormUIStepObject : RSDUIStepObject, RSDFormUIStep, RSDSurveyNavigationStep, RSDCohortAssignmentStep {
 
     /// The `inputFields` array is used to hold a logical subgrouping of input fields.
     open private(set) var inputFields: [RSDInputField]
@@ -77,36 +78,48 @@ open class RSDFormUIStepObject : RSDUIStepObject, RSDFormUIStep, RSDSurveyNaviga
     
     /// Identifier for the next step to navigate to based on the current task result.
     ///
-    /// - note: The conditional rule is ignored by this implementation of the navigation rule. Instead, this will
-    ///         evaluate any survey rules and the direct navigation rule inherited from `RSDUIStepObject`.
+    /// - note: The conditional rule is ignored by this implementation of the navigation rule. Instead,
+    /// this will evaluate any survey rules and the direct navigation rule inherited from
+    /// `RSDUIStepObject`.
     ///
     /// - parameters:
     ///     - result:           The current task result.
     ///     - conditionalRule:  The conditional rule associated with this task. (Ignored)
-    ///     - isPeeking:        Is this navigation rule being called on a result for a step that is navigating
-    ///                         forward or is it a step navigator that is peeking at the next step to set up UI
-    ///                         display? If peeking at the next step then this parameter will be `true`.
+    ///     - isPeeking:        Is this navigation rule being called on a result for a step that is
+    ///                         navigating forward or is it a step navigator that is peeking at the next
+    ///                         step to set up UI display? If peeking at the next step then this
+    ///                         parameter will be `true`.
     /// - returns: The identifier of the next step.
     open override func nextStepIdentifier(with result: RSDTaskResult?, conditionalRule: RSDConditionalRule?, isPeeking: Bool) -> String? {
         return self.evaluateSurveyRules(with: result, isPeeking: isPeeking) ?? self.nextStepIdentifier
+    }
+    
+    /// Evaluate the task result and return the set of cohorts to add and remove. Default implementation
+    /// calls
+    /// `evaluateCohortsToApply(with:)`.
+    ///
+    /// - parameter result: The task result to evaluate.
+    /// - returns: The cohorts to add/remove or `nil` if no rules apply.
+    open func cohortsToApply(with result: RSDTaskResult) -> (add: Set<String>, remove: Set<String>)? {
+        return self.evaluateCohortsToApply(with: result)
     }
     
     private enum CodingKeys: String, CodingKey {
         case inputFields
     }
     
-    /// Initialize from a `Decoder`. This implementation will query the `RSDFactory` attached to the decoder for the
-    /// appropriate implementation for each input field in the array.
+    /// Initialize from a `Decoder`. This implementation will query the `RSDFactory` attached to the
+    /// decoder for the appropriate implementation for each input field in the array.
     ///
-    /// - note: This method will also check for both an array of input fields and in order to support existing serialization
-    ///         methods defined prior to the developement of the Swift 4 `Decodable` protocol, it will also recognize a single
-    ///         input field defined inline as a single question.
+    /// - note: This method will also check for both an array of input fields and in order to support
+    /// existing serialization methods defined prior to the developement of the Swift 4 `Decodable`
+    /// protocol, it will also recognize a single input field defined inline as a single question.
     ///
     /// - example:
     ///
     ///     ```
-    ///         // Example JSON dictionary that includes a date, integer, and multiple choice question defined
-    ///         // in an array of dictionaries keyed to "inputFields".
+    ///         // Example JSON dictionary that includes a date, integer, and multiple choice question
+    ///         // defined in an array of dictionaries keyed to "inputFields".
     ///         let json = """
     ///             {
     ///             "identifier": "step3",
@@ -137,8 +150,8 @@ open class RSDFormUIStepObject : RSDUIStepObject, RSDFormUIStep, RSDSurveyNaviga
     ///             }
     ///         """.data(using: .utf8)! // our data in native (JSON) format
     ///
-    ///         // Example JSON dictionary that includes a multiple choice question where the input field properties are
-    ///         // defined inline and *not* using an array.
+    ///         // Example JSON dictionary that includes a multiple choice question where the input field
+    ///         // properties are defined inline and *not* using an array.
     ///         let json = """
     ///             {
     ///             "identifier": "step3",
@@ -175,14 +188,16 @@ open class RSDFormUIStepObject : RSDUIStepObject, RSDFormUIStep, RSDSurveyNaviga
         try super.init(from: decoder)
     }
     
-    /// Instantiate a step result that is appropriate for this step. The default for this class is a `RSDCollectionResultObject`.
+    /// Instantiate a step result that is appropriate for this step. The default for this class is a
+    /// `RSDCollectionResultObject`.
     /// - returns: A result for this step.
     open override func instantiateStepResult() -> RSDResult {
         return RSDCollectionResultObject(identifier: self.identifier)
     }
 
-    /// Validate the step to check for any configuration that should throw an error. This class will check that the input
-    /// fields have unique identifiers and will call the `validate()` method on each input field.
+    /// Validate the step to check for any configuration that should throw an error. This class will
+    /// check that the input fields have unique identifiers and will call the `validate()` method on each
+    /// input field.
     ///
     /// - throws: An error if validation fails.
     open override func validate() throws {

--- a/ResearchSuite/ResearchSuite/RSDIdentifier.swift
+++ b/ResearchSuite/ResearchSuite/RSDIdentifier.swift
@@ -49,6 +49,7 @@ public struct RSDIdentifier : RawRepresentable, Codable {
     
     public static let exit: RSDIdentifier = "exit"
     public static let nextSection: RSDIdentifier = "nextSection"
+    public static let nextStep: RSDIdentifier = "nextStep"
     
     public static func allGlobalIdentifiers() -> [RSDIdentifier] {
         return [.exit, .nextSection]

--- a/ResearchSuite/ResearchSuite/RSDImageWrapper.swift
+++ b/ResearchSuite/ResearchSuite/RSDImageWrapper.swift
@@ -104,8 +104,8 @@ public struct RSDImageWrapper {
                 else {
                     throw RSDValidationError.invalidImageName("Invalid image name: \(imageName)")
             }
+            return .zero
         #endif
-        return .zero
     }
     
     /// Fetch the image.

--- a/ResearchSuite/ResearchSuite/RSDTaskPath.swift
+++ b/ResearchSuite/ResearchSuite/RSDTaskPath.swift
@@ -2,7 +2,7 @@
 //  RSDTaskPath.swift
 //  ResearchSuite
 //
-//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//  Copyright © 2017-2018 Sage Bionetworks. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
 // are permitted provided that the following conditions are met:

--- a/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableInputFieldObjectTests.swift
+++ b/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableInputFieldObjectTests.swift
@@ -353,7 +353,8 @@ class CodableInputFieldObjectTests: XCTestCase {
                             {
                             "skipToIdentifier": "lessThan",
                             "ruleOperator": "lt",
-                            "matchingAnswer": 0
+                            "matchingAnswer": 0,
+                            "cohort": "less"
                             },
                             {
                             "skipToIdentifier": "greaterThan",
@@ -388,6 +389,7 @@ class CodableInputFieldObjectTests: XCTestCase {
                 XCTAssertEqual(firstRule.skipToIdentifier, "lessThan")
                 XCTAssertEqual(firstRule.ruleOperator, .lessThan)
                 XCTAssertEqual(firstRule.matchingAnswer as? Int, 0)
+                XCTAssertEqual(firstRule.cohort, "less")
                 
                 XCTAssertEqual(lastRule.skipToIdentifier, "greaterThan")
                 XCTAssertEqual(lastRule.ruleOperator, .greaterThan)

--- a/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableStepObjectTests.swift
+++ b/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableStepObjectTests.swift
@@ -175,7 +175,13 @@ class CodableStepObjectTests: XCTestCase {
                                },
             "colorTheme"     : { "backgroundColor" : "sky", "foregroundColor" : "cream", "usesLightStyle" : true },
             "viewTheme"      : { "viewIdentifier": "ActiveInstruction",
-                                 "storyboardIdentifier": "ActiveTaskSteps" }
+                                 "storyboardIdentifier": "ActiveTaskSteps" },
+            "beforeCohortRules" : [{ "requiredCohorts" : ["boo", "goo"],
+                                    "skipToIdentifier" : "blueGu",
+                                    "operator" : "any" }],
+            "afterCohortRules" : [{ "requiredCohorts" : ["foo", "baloo"],
+                                    "skipToIdentifier" : "foomanchu",
+                                    "operator" : "all" }]
         }
         """.data(using: .utf8)! // our data in native (JSON) format
         
@@ -228,6 +234,22 @@ class CodableStepObjectTests: XCTestCase {
             
             XCTAssertEqual(object.viewTheme?.storyboardIdentifier, "ActiveTaskSteps")
             XCTAssertEqual(object.viewTheme?.viewIdentifier, "ActiveInstruction")
+            
+            if let cohortRule = object.beforeCohortRules?.first {
+                XCTAssertEqual(cohortRule.requiredCohorts, ["boo", "goo"])
+                XCTAssertEqual(cohortRule.skipToIdentifier, "blueGu")
+                XCTAssertEqual(cohortRule.cohortOperator, .any)
+            } else {
+                XCTFail("Failed to decode before cohort rules")
+            }
+            
+            if let cohortRule = object.afterCohortRules?.first {
+                XCTAssertEqual(cohortRule.requiredCohorts, ["foo", "baloo"])
+                XCTAssertEqual(cohortRule.skipToIdentifier, "foomanchu")
+                XCTAssertEqual(cohortRule.cohortOperator, .all)
+            } else {
+                XCTFail("Failed to decode before cohort rules")
+            }
             
         } catch let err {
             XCTFail("Failed to decode/encode object: \(err)")

--- a/ResearchSuite/ResearchSuiteTests/ModelObject Tests/StepTests.swift
+++ b/ResearchSuite/ResearchSuiteTests/ModelObject Tests/StepTests.swift
@@ -64,6 +64,8 @@ class StepTests: XCTestCase {
         step.commands = [.continueOnFinish]
         step.spokenInstructions = [0 : "start"]
         step.requiresBackgroundAudio = true
+        step.beforeCohortRules = [RSDCohortNavigationRuleObject(requiredCohorts: ["boo"], cohortOperator: nil, skipToIdentifier: nil)]
+        step.afterCohortRules = [RSDCohortNavigationRuleObject(requiredCohorts: ["goo"], cohortOperator: nil, skipToIdentifier: nil)]
         
         let copy = step.copy(with: "bar")
         XCTAssertEqual(copy.identifier, "bar")
@@ -82,19 +84,29 @@ class StepTests: XCTestCase {
         } else {
             XCTFail("\(String(describing: copy.actions)) does not include expected learn more action")
         }
-        if let shouldHideActions = step.shouldHideActions {
+        if let shouldHideActions = copy.shouldHideActions {
             XCTAssertEqual(shouldHideActions, [.navigation(.skip)])
         } else {
-            XCTAssertNotNil(step.shouldHideActions)
+            XCTAssertNotNil(copy.shouldHideActions)
         }
         XCTAssertEqual(copy.duration, 5)
         XCTAssertEqual(copy.commands, [.continueOnFinish])
-        if let spokenInstructions = step.spokenInstructions {
+        if let spokenInstructions = copy.spokenInstructions {
             XCTAssertEqual(spokenInstructions, [0 : "start"])
         } else {
-            XCTAssertNotNil(step.spokenInstructions)
+            XCTAssertNotNil(copy.spokenInstructions)
         }
         XCTAssertTrue(copy.requiresBackgroundAudio)
+        if let cohort = copy.beforeCohortRules?.first {
+            XCTAssertEqual(cohort.requiredCohorts, ["boo"])
+        } else {
+            XCTAssertNotNil(copy.beforeCohortRules?.first)
+        }
+        if let cohort = copy.afterCohortRules?.first {
+            XCTAssertEqual(cohort.requiredCohorts, ["goo"])
+        } else {
+            XCTAssertNotNil(copy.beforeCohortRules?.first)
+        }
     }
     
     func testCopy_FormUIStepObject() {
@@ -128,10 +140,10 @@ class StepTests: XCTestCase {
         } else {
             XCTFail("\(String(describing: copy.actions)) does not include expected learn more action")
         }
-        if let shouldHideActions = step.shouldHideActions {
+        if let shouldHideActions = copy.shouldHideActions {
             XCTAssertEqual(shouldHideActions, [.navigation(.skip)])
         } else {
-            XCTAssertNotNil(step.shouldHideActions)
+            XCTAssertNotNil(copy.shouldHideActions)
         }
         
         XCTAssertEqual(copy.inputFields.count, 1)
@@ -189,10 +201,10 @@ class StepTests: XCTestCase {
         } else {
             XCTFail("\(String(describing: copy.actions)) does not include expected learn more action")
         }
-        if let shouldHideActions = step.shouldHideActions {
+        if let shouldHideActions = copy.shouldHideActions {
             XCTAssertEqual(shouldHideActions, [.navigation(.skip)])
         } else {
-            XCTAssertNotNil(step.shouldHideActions)
+            XCTAssertNotNil(copy.shouldHideActions)
         }
     }
     


### PR DESCRIPTION
I decided to call them "cohorts". I don't recall why we landed on "data groups" but in thinking about how to describe what this is tracking, I kept using the word "cohort" and so it seemed to make more sense for a shared research framework.