### PR TITLE
Resource management and permissions

### DIFF
--- a/ResearchSuite/ResearchSuite.xcodeproj/project.pbxproj
+++ b/ResearchSuite/ResearchSuite.xcodeproj/project.pbxproj
@@ -945,6 +945,7 @@
 		F8E94FEA20585B7800752B7B /* Permissions */ = {
 			isa = PBXGroup;
 			children = (
+				FFB015DF1F8C081200AC209B /* RSDStandardPermissionType.swift */,
 				F8E94FEB20585BE400752B7B /* RSDAudioVisualAuthorization.swift */,
 				F8E94FF020585ED100752B7B /* RSDLocationAuthorization.swift */,
 				F8E94FF42058602F00752B7B /* RSDMotionAuthorization.swift */,
@@ -1293,7 +1294,6 @@
 				F88051A12011B43700B0FDDD /* RSDFraction.swift */,
 				FF80B1381F7C244200582849 /* RSDIdentifier.swift */,
 				FFF53EAC1FBF9562004211D2 /* RSDResultType.swift */,
-				FFB015DF1F8C081200AC209B /* RSDStandardPermissionType.swift */,
 				FFD38DE61FBF805F004203D8 /* RSDStepType.swift */,
 				F8BAF41E2048DD35004B9406 /* RSDStepNavigatorType.swift */,
 			);

--- a/ResearchSuite/ResearchSuite/Codable+Utilities.swift
+++ b/ResearchSuite/ResearchSuite/Codable+Utilities.swift
@@ -36,8 +36,8 @@ import Foundation
 extension Dictionary {
     
     /// Use this dictionary to decode the given object type.
-    public func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
-        let decoder = RSDFactory.shared.createJSONDecoder()
+    public func decode<T>(_ type: T.Type, bundle: Bundle? = nil) throws -> T where T : Decodable {
+        let decoder = RSDFactory.shared.createJSONDecoder(bundle: bundle)
         let jsonData = try JSONSerialization.data(withJSONObject: self, options: [])
         let decodable = try decoder.decode(type, from: jsonData)
         return decodable
@@ -47,8 +47,8 @@ extension Dictionary {
 extension Array {
     
     /// Use this array to decode an array of objects of the given type.
-    public func decode<T>(_ type: Array<T>.Type) throws -> Array<T> where T : Decodable {
-        let decoder = RSDFactory.shared.createJSONDecoder()
+    public func decode<T>(_ type: Array<T>.Type, bundle: Bundle? = nil) throws -> Array<T> where T : Decodable {
+        let decoder = RSDFactory.shared.createJSONDecoder(bundle: bundle)
         let jsonData = try JSONSerialization.data(withJSONObject: self, options: [])
         let decodable = try decoder.decode(type, from: jsonData)
         return decodable

--- a/ResearchSuite/ResearchSuite/RSDColorThemeElementObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDColorThemeElementObject.swift
@@ -33,15 +33,13 @@
 
 import Foundation
 
-/// `RSDColorThemeElementObject` tells the UI what the background color and foreground color are for a given view as
-/// well as whether or not the foreground elements should use "light style".
+/// `RSDColorThemeElementObject` tells the UI what the background color and foreground color are for a
+/// given view as well as whether or not the foreground elements should use "light style".
 public struct RSDColorThemeElementObject : RSDColorThemeElement, RSDDecodableBundleInfo, Codable {
     let _backgroundColorName: String?
     let _foregroundColorName: String?
     let _usesLightStyle: Bool?
     
-    public let bundleIdentifier: String?
-
     private enum CodingKeys: String, CodingKey {
         case _backgroundColorName = "backgroundColor"
         case _foregroundColorName = "foregroundColor"
@@ -49,7 +47,14 @@ public struct RSDColorThemeElementObject : RSDColorThemeElement, RSDDecodableBun
         case bundleIdentifier
     }
     
-    /// Hint for whether or not the view uses light style for things like the progress bar and navigation buttons.
+    /// The bundle identifier.
+    public let bundleIdentifier: String?
+    
+    /// The default bundle from the factory used to decode this object.
+    public var factoryBundle: Bundle? = nil
+    
+    /// Hint for whether or not the view uses light style for things like the progress bar and navigation
+    /// buttons.
     public var usesLightStyle: Bool {
         return _usesLightStyle ?? false
     }
@@ -106,16 +111,19 @@ public struct RSDColorThemeElementObject : RSDColorThemeElement, RSDDecodableBun
     ///
     /// - note: The color names used by this `Codable` object can be defined as either:
     /// 1. HEX-code values.
-    /// 2. Using a Color Asset if targeting devices that support this feature. For example, iOS 11 and above.
-    ///     See https://developer.apple.com/documentation/uikit/uicolor/2877380-init for more information.
-    /// 3. A mapping file called "ColorInfo.plist" that includes key/value pairs where the `key` is the name included
-    ///     here and the `value` is a HEX-code color.
+    /// 2. Using a Color Asset if targeting devices that support this feature. For example, iOS 11 and
+    ///    above.
+    ///    See https://developer.apple.com/documentation/uikit/uicolor/2877380-init for more information.
+    /// 3. A mapping file called "ColorInfo.plist" that includes key/value pairs where the `key` is the
+    ///    name included here and the `value` is a HEX-code color.
     ///
     /// - parameters:
-    ///     - usesLightStyle: Hint for whether or not the view uses light style for things like the progress bar. Default = `false`.
+    ///     - usesLightStyle: Hint for whether or not the view uses light style for things like the
+    ///       progress bar. Default = `false`.
     ///     - backgroundColorName: The name of the background color. Default = `nil`.
     ///     - foregroundColorName: The name of the foreground color. Default = `nil`.
-    ///     - bundleIdentifier: The bundle identifier for where to find the color asset or plist mapping file. Default = `nil`.
+    ///     - bundleIdentifier: The bundle identifier for where to find the color asset or plist mapping
+    ///       file. Default = `nil`.
     public init(usesLightStyle: Bool = false, backgroundColorName: String?, foregroundColorName: String? = nil, bundleIdentifier: String? = nil) {
         self._usesLightStyle = usesLightStyle
         self._backgroundColorName = backgroundColorName

--- a/ResearchSuite/ResearchSuite/RSDImageThemeObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDImageThemeObject.swift
@@ -53,6 +53,10 @@ extension RSDImageWrapper : RSDFetchableImageThemeElement {
 
 /// `RSDFetchableImageThemeElementObject` is a `Codable` concrete implementation of `RSDFetchableImageThemeElement`.
 public struct RSDFetchableImageThemeElementObject : RSDFetchableImageThemeElement, RSDDecodableBundleInfo, Codable {
+    
+    private enum CodingKeys: String, CodingKey {
+        case imageName, bundleIdentifier, placementType, _size = "size"
+    }
 
     /// The name of the image.
     public let imageName: String
@@ -69,16 +73,15 @@ public struct RSDFetchableImageThemeElementObject : RSDFetchableImageThemeElemen
     }
     private let _size: RSDSizeWrapper?
     
+    /// The default bundle from the factory used to decode this object.
+    public var factoryBundle: Bundle? = nil
+    
     /// The unique identifier for the image
     public var imageIdentifier: String {
         guard let bundleIdentifier = bundleIdentifier else { return imageName }
         return "\(bundleIdentifier).\(imageName)"
     }
-    
-    private enum CodingKeys: String, CodingKey {
-        case imageName, bundleIdentifier, placementType, _size = "size"
-    }
-    
+
     /// Default initializer.
     ///
     /// - parameters:
@@ -113,6 +116,10 @@ public struct RSDFetchableImageThemeElementObject : RSDFetchableImageThemeElemen
 /// `RSDAnimatedImageThemeElementObject` is a `Codable` concrete implementation of `RSDAnimatedImageThemeElement`.
 public struct RSDAnimatedImageThemeElementObject : RSDAnimatedImageThemeElement, RSDDecodableBundleInfo, Codable {
     
+    private enum CodingKeys: String, CodingKey {
+        case imageNames, animationDuration, bundleIdentifier, placementType, _size = "size"
+    }
+    
     /// The list of image names for the images to include in this animation.
     public let imageNames: [String]
     
@@ -136,10 +143,9 @@ public struct RSDAnimatedImageThemeElementObject : RSDAnimatedImageThemeElement,
         guard let bundleIdentifier = bundleIdentifier else { return imageNames.first! }
         return "\(bundleIdentifier).\(imageNames.first!)"
     }
-
-    private enum CodingKeys: String, CodingKey {
-        case imageNames, animationDuration, bundleIdentifier, placementType, _size = "size"
-    }
+    
+    /// The default bundle from the factory used to decode this object.
+    public var factoryBundle: Bundle? = nil
 
     /// Default initializer.
     ///

--- a/ResearchSuite/ResearchSuite/RSDImageWrapper.swift
+++ b/ResearchSuite/ResearchSuite/RSDImageWrapper.swift
@@ -202,7 +202,7 @@ extension RSDImageWrapper : Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let imageName = try container.decode(String.self)
-        self.size = try RSDImageWrapper.validate(imageName: imageName, bundle: nil)
+        self.size = try RSDImageWrapper.validate(imageName: imageName, bundle: decoder.bundle)
         self.imageName = imageName
     }
 }

--- a/ResearchSuite/ResearchSuite/RSDMotionAuthorization.swift
+++ b/ResearchSuite/ResearchSuite/RSDMotionAuthorization.swift
@@ -71,7 +71,8 @@ public class RSDMotionAuthorization {
                 if let err = error {
                     debugPrint("Failed to query pedometer: \(err)")
                     setCachedAuthorization(false)
-                    completion(.denied, err)
+                    let error = RSDPermissionError.notAuthorized(.motion, .denied)
+                    completion(.denied, error)
                 } else {
                     pedometer = nil
                     setCachedAuthorization(true)

--- a/ResearchSuite/ResearchSuite/RSDResourceTransformer.swift
+++ b/ResearchSuite/ResearchSuite/RSDResourceTransformer.swift
@@ -33,15 +33,39 @@
 
 import Foundation
 
-/// `RSDResourceConfig` is designed as an overridable resource configuration manager. The functions and properties
-/// are intended to be overridable in the app by implementing a custom extension of the function with the same name.
-/// This is designed to use app-wins namespace conflict resolution that is typical of obj-c architecture.
+/// `RSDDecodableBundleInfo` is a convenience protocol for getting a bundle from a bundle identifier.
+public protocol RSDDecodableBundleInfo : Decodable {
+    
+    /// The bundle identifier. Decodable identifier that can be used to get the bundle.
+    var bundleIdentifier : String? { get }
+    
+    /// A pointer to the bundle set by the factory (if applicable)
+    var factoryBundle: Bundle? { get set }
+}
+
+extension RSDDecodableBundleInfo {
+    
+    /// The bundle returned for the given `bundleIdentifier` or `factoryBundle` if `nil`.
+    public var bundle: Bundle? {
+        guard let identifier = bundleIdentifier
+            else {
+                return self.factoryBundle
+        }
+        return Bundle(identifier: identifier)
+    }
+}
+
+/// `RSDResourceConfig` is designed as an overridable resource configuration manager. The functions and
+/// properties are intended to be overridable in the app by implementing a custom extension of the function
+/// with the same name. This is designed to use app-wins namespace conflict resolution that is typical of
+/// obj-c architecture.
 open class RSDResourceConfig : NSObject {
 }
 
 extension RSDResourceConfig {
     
-    /// Queries the resource config for the relative URL for a given resource object. Default return is `nil`.
+    /// Queries the resource config for the relative URL for a given resource object. Default return is
+    /// `nil`.
     ///
     /// - parameter resource: The resource object.
     /// - returns: The relative URL to apply to the resource object.
@@ -64,8 +88,8 @@ extension RSDResourceConfig {
 ///
 public protocol RSDResourceTransformer: RSDDecodableBundleInfo {
     
-    /// Either a fully qualified URL string or else a relative reference to either an embedded resource or a
-    /// relative URL defined globally by overriding the `RSDResourceConfig` class methods.
+    /// Either a fully qualified URL string or else a relative reference to either an embedded resource or
+    /// a relative URL defined globally by overriding the `RSDResourceConfig` class methods.
     var resourceName: String { get }
     
     /// The classType for converting the resource to an object.
@@ -117,6 +141,9 @@ extension RSDResourceTransformer {
         let rBundle: Bundle
         if bundle != nil {
             rBundle = bundle!
+        }
+        else if self.factoryBundle != nil {
+            rBundle = self.factoryBundle!
         }
         else if let relativeBundle = RSDResourceConfig.resourceBundle(for: self) {
             rBundle = relativeBundle

--- a/ResearchSuite/ResearchSuite/RSDResourceTransformer.swift
+++ b/ResearchSuite/ResearchSuite/RSDResourceTransformer.swift
@@ -39,7 +39,7 @@ public protocol RSDDecodableBundleInfo : Decodable {
     /// The bundle identifier. Decodable identifier that can be used to get the bundle.
     var bundleIdentifier : String? { get }
     
-    /// A pointer to the bundle set by the factory (if applicable)
+    /// A pointer to the bundle set by the factory (if applicable).
     var factoryBundle: Bundle? { get set }
 }
 

--- a/ResearchSuite/ResearchSuite/RSDResourceTransformerObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDResourceTransformerObject.swift
@@ -33,20 +33,23 @@
 
 import Foundation
 
-/// `RSDResourceTransformerObject` is a concrete implementation of a codable resource transformer. The transformer
-/// can be used to create an object decoded from an embedded resource.
+/// `RSDResourceTransformerObject` is a concrete implementation of a codable resource transformer.
+/// The transformer can be used to create an object decoded from an embedded resource.
 public final class RSDResourceTransformerObject : Codable {
     
-    /// Either a fully qualified URL string or else a relative reference to either an embedded resource or a
-    /// relative URL defined globally by overriding the `RSDResourceConfig` class methods.
+    /// Either a fully qualified URL string or else a relative reference to either an embedded resource or
+    /// a relative URL defined globally by overriding the `RSDResourceConfig` class methods.
     public let resourceName: String
     
     /// The bundle identifier for the embedded resource.
     public let bundleIdentifier: String?
     
-    /// The classType for converting the resource to an object. This is a hint that subclasses of `RsDFactory` can
-    /// use to determine the type of object to instantiate.
+    /// The classType for converting the resource to an object. This is a hint that subclasses of
+    /// `RSDFactory` can use to determine the type of object to instantiate.
     public let classType: String?
+    
+    /// The default bundle from the factory used to decode this object.
+    public var factoryBundle: Bundle? = nil
     
     private enum CodingKeys: String, CodingKey {
         case resourceName, bundleIdentifier, classType
@@ -61,6 +64,19 @@ public final class RSDResourceTransformerObject : Codable {
     public init(resourceName: String, bundleIdentifier: String? = nil, classType: String? = nil) {
         self.resourceName = resourceName
         self.bundleIdentifier = bundleIdentifier
+        self.classType = classType
+    }
+    
+    /// Default initializer for creating the object.
+    ///
+    /// - parameters:
+    ///     - resourceName: The name of the resource.
+    ///     - bundleIdentifier: The bundle identifier for the embedded resource.
+    ///     - classType: The classType for converting the resource to an object.
+    public init(resourceName: String, bundle: Bundle, classType: String? = nil) {
+        self.resourceName = resourceName
+        self.bundleIdentifier = bundle.bundleIdentifier
+        self.factoryBundle = bundle
         self.classType = classType
     }
 }

--- a/ResearchSuite/ResearchSuite/RSDSampleRecorder.swift
+++ b/ResearchSuite/ResearchSuite/RSDSampleRecorder.swift
@@ -128,12 +128,6 @@ open class RSDSampleRecorder : NSObject, RSDAsyncActionController {
         
         /// Returned when the recorder that has been cancelled, failed, or finished.
         case finished
-        
-        /// Error to return if one or more required permissions are denied.
-        case permissionDenied
-        
-        /// Error to return if the permission is not available.
-        case notAvailable
     }
     
     /// Default initializer.

--- a/ResearchSuite/ResearchSuite/RSDSectionStep.swift
+++ b/ResearchSuite/ResearchSuite/RSDSectionStep.swift
@@ -101,6 +101,9 @@ public protocol RSDTransformerStep: RSDStep {
 /// - seealso: `RSDSectionStep`, `RSDTransformerStepObject` and `RSDFactory`
 public protocol RSDSectionStepTransformer {
     
+    /// The bundle to use to pull resources.
+    var bundle: Bundle? { get }
+    
     /// Fetch the steps for this section.
     ///
     /// - parameter factory: The factory to use for creating the task and steps.
@@ -122,7 +125,7 @@ extension RSDSectionStepResourceTransformer {
     /// - returns: The steps for this section.
     public func transformSteps(with factory: RSDFactory) throws -> [RSDStep] {
         let (data, resourceType) = try self.resourceData()
-        let decoder = try factory.createDecoder(for: resourceType)
+        let decoder = try factory.createDecoder(for: resourceType, taskIdentifier: nil, schemaInfo: nil, bundle: self.bundle)
         let stepDecoder = try decoder.decode(_StepsDecoder.self, from: data)
         return stepDecoder.steps
     }

--- a/ResearchSuite/ResearchSuite/RSDStandardPermissionType.swift
+++ b/ResearchSuite/ResearchSuite/RSDStandardPermissionType.swift
@@ -197,5 +197,50 @@ public struct RSDStandardPermission : Codable {
         }
     }
     private var _deniedMessage: String?
+    
+    /// Returns the message appropriate to the status
+    public func message(for status: RSDAuthorizationStatus) -> String? {
+        switch status {
+        case .denied, .previouslyDenied:
+            return self.deniedMessage
+        case .restricted:
+            return self.restrictedMessage
+        default:
+            return nil
+        }
+    }
 }
 
+/// `RSDPermissionError` errors are thrown when a task, step, or async action does not have a permission that
+/// is required to run the action.
+public enum RSDPermissionError : Error {
+    
+    /// Permission denied.
+    case notAuthorized(RSDStandardPermission, RSDAuthorizationStatus)
+    
+    /// The localized message for this error.
+    public var localizedDescription: String {
+        switch(self) {
+        case .notAuthorized(let permission, let status):
+            return permission.message(for: status) ?? "\(permission) : \(status)"
+        }
+    }
+    
+    /// The domain of the error.
+    public static var errorDomain: String {
+        return "RSDPermissionErrorDomain"
+    }
+    
+    /// The error code within the given domain.
+    public var errorCode: Int {
+        switch(self) {
+        case .notAuthorized(_, let status):
+            return status.rawValue
+        }
+    }
+    
+    /// The user-info dictionary.
+    public var errorUserInfo: [String : Any] {
+        return ["NSDebugDescription": self.localizedDescription]
+    }
+}

--- a/ResearchSuite/ResearchSuite/RSDStandardPermissionType.swift
+++ b/ResearchSuite/ResearchSuite/RSDStandardPermissionType.swift
@@ -198,7 +198,7 @@ public struct RSDStandardPermission : Codable {
     }
     private var _deniedMessage: String?
     
-    /// Returns the message appropriate to the status
+    /// Returns the message appropriate to the status.
     public func message(for status: RSDAuthorizationStatus) -> String? {
         switch status {
         case .denied, .previouslyDenied:

--- a/ResearchSuite/ResearchSuite/RSDThemedUIStep.swift
+++ b/ResearchSuite/ResearchSuite/RSDThemedUIStep.swift
@@ -53,22 +53,6 @@ public protocol RSDUIThemeElement {
     var bundle: Bundle? { get }
 }
 
-/// `RSDDecodableBundleInfo` is a convenience protocol for getting a bundle from a bundle identifier.
-public protocol RSDDecodableBundleInfo {
-    
-    /// The bundle identifier.
-    var bundleIdentifier : String? { get }
-}
-
-extension RSDDecodableBundleInfo {
-    
-    /// The bundle returned for the given `bundleIdentifier`.
-    public var bundle: Bundle? {
-        guard let identifier = bundleIdentifier else { return nil }
-        return Bundle(identifier: identifier)
-    }
-}
-
 /// `RSDViewThemeElement` tells the UI where to find the view controller to use when instantiating the
 /// `RSDStepController`.
 public protocol RSDViewThemeElement : RSDUIThemeElement {

--- a/ResearchSuite/ResearchSuite/RSDUIActionObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDUIActionObject.swift
@@ -58,6 +58,10 @@ extension RSDEmbeddedResourceUIAction {
 /// title and image displayed for a given action of the UI.
 public struct RSDUIActionObject : RSDEmbeddedResourceUIAction, Codable {
     
+    private enum CodingKeys : String, CodingKey {
+        case buttonTitle, iconName, bundleIdentifier
+    }
+    
     /// The title to display on the button associated with this action.
     public var buttonTitle: String?
     
@@ -66,6 +70,9 @@ public struct RSDUIActionObject : RSDEmbeddedResourceUIAction, Codable {
     
     /// The bundle identifier for the resource bundle that contains the image.
     public var bundleIdentifier: String?
+    
+    /// The default bundle from the factory used to decode this object.
+    public var factoryBundle: Bundle? = nil
     
     /// Default initializer for a button with text.
     /// - parameter buttonTitle: The title to display on the button associated with this action.
@@ -83,16 +90,16 @@ public struct RSDUIActionObject : RSDEmbeddedResourceUIAction, Codable {
         self.iconName = iconName
         self.bundleIdentifier = bundleIdentifier
     }
-    
-    private enum CodingKeys : String, CodingKey {
-        case buttonTitle, iconName, bundleIdentifier
-    }
 }
 
 /// `RSDSkipToUIActionObject` implements an action that includes an identifier for a step to skip to if this
 /// action is called. This is used by the `RSDConditionalStepNavigator` to navigate based on a `nil` result.
 /// - seealso: `RSDSurveyNavigationStep`
 public struct RSDSkipToUIActionObject : RSDEmbeddedResourceUIAction, RSDSkipToUIAction {
+    
+    private enum CodingKeys : String, CodingKey {
+        case skipToIdentifier, buttonTitle, iconName, bundleIdentifier
+    }
     
     /// The identifier for the step to skip to if the action is called.
     public let skipToIdentifier: String
@@ -105,6 +112,9 @@ public struct RSDSkipToUIActionObject : RSDEmbeddedResourceUIAction, RSDSkipToUI
     
     /// The bundle identifier for the resource bundle that contains the image.
     public var bundleIdentifier: String?
+    
+    /// The default bundle from the factory used to decode this object.
+    public var factoryBundle: Bundle? = nil
     
     /// Default initializer for a button with text.
     /// - parameters:
@@ -124,12 +134,6 @@ public struct RSDSkipToUIActionObject : RSDEmbeddedResourceUIAction, RSDSkipToUI
         self.skipToIdentifier = skipToIdentifier
         self.iconName = iconName
         self.bundleIdentifier = bundleIdentifier
-    }
-    
-    // MARK: Codable implementation (auto synthesized implementation does not work with subclassing)
-    
-    private enum CodingKeys : String, CodingKey {
-        case skipToIdentifier, buttonTitle, iconName, bundleIdentifier
     }
 }
 
@@ -156,6 +160,9 @@ public struct RSDReminderUIActionObject : RSDEmbeddedResourceUIAction {
     /// The bundle identifier for the resource bundle that contains the image.
     public var bundleIdentifier: String?
     
+    /// The default bundle from the factory used to decode this object.
+    public var factoryBundle: Bundle? = nil
+    
     /// Default initializer for a button with text.
     /// - parameters:
     ///     - reminderIdentifier:  The identifier for a `UNNotificationRequest`.
@@ -167,12 +174,15 @@ public struct RSDReminderUIActionObject : RSDEmbeddedResourceUIAction {
 }
 
 /// `RSDWebViewUIActionObject` implements an action that includes a pointer to a url that can display in a
-/// webview. The url can either be fully qualified or optionally point to an embedded resource. The resource
-/// bundle is assumed to be the main bundle if the `bundleIdentifier` property is `nil`.
+/// webview. The url can either be fully qualified or optionally point to an embedded resource. 
 public struct RSDWebViewUIActionObject : RSDEmbeddedResourceUIAction, RSDWebViewUIAction {
 
-    /// The url to load in the webview. If this is not a fully qualified url string, then it is assumed to refer
-    /// to an embedded resource.
+    private enum CodingKeys : String, CodingKey {
+        case  url, buttonTitle, iconName, bundleIdentifier
+    }
+    
+    /// The url to load in the webview. If this is not a fully qualified url string, then it is assumed to
+    /// refer to an embedded resource.
     public let url: String
     
     /// The title to display on the button associated with this action.
@@ -183,6 +193,9 @@ public struct RSDWebViewUIActionObject : RSDEmbeddedResourceUIAction, RSDWebView
     
     /// The bundle identifier for the resource bundle that contains the image.
     public var bundleIdentifier: String?
+    
+    /// The default bundle from the factory used to decode this object.
+    public var factoryBundle: Bundle? = nil
     
     /// The `url` is the resource name.
     public var resourceName: String {
@@ -215,12 +228,6 @@ public struct RSDWebViewUIActionObject : RSDEmbeddedResourceUIAction, RSDWebView
         self.url = url
         self.iconName = iconName
         self.bundleIdentifier = bundleIdentifier
-    }
-    
-    // MARK: Codable implementation (auto synthesized implementation does not work with subclassing)
-    
-    private enum CodingKeys : String, CodingKey {
-        case  url, buttonTitle, iconName, bundleIdentifier
     }
 }
 

--- a/ResearchSuite/ResearchSuite/RSDViewThemeElementObject.swift
+++ b/ResearchSuite/ResearchSuite/RSDViewThemeElementObject.swift
@@ -33,9 +33,13 @@
 
 import Foundation
 
-/// `RSDViewThemeElementObject` tells the UI where to find the view controller to use when instantiating the
-/// `RSDStepController`.
+/// `RSDViewThemeElementObject` tells the UI where to find the view controller to use when instantiating
+/// the `RSDStepController`.
 public struct RSDViewThemeElementObject: RSDViewThemeElement, RSDDecodableBundleInfo, Codable {
+    
+    private enum CodingKeys: String, CodingKey {
+        case viewIdentifier, bundleIdentifier, storyboardIdentifier
+    }
     
     /// The storyboard view controller identifier or the nib name for this view controller.
     public let viewIdentifier: String
@@ -43,18 +47,18 @@ public struct RSDViewThemeElementObject: RSDViewThemeElement, RSDDecodableBundle
     /// The bundle identifier for the nib or storyboard.
     public let bundleIdentifier: String?
     
-    /// If the storyboard identifier is non-nil then the view is assumed to be accessible within the storyboard
-    /// via the `viewIdentifier`.
+    /// If the storyboard identifier is non-nil then the view is assumed to be accessible within the
+    /// storyboard via the `viewIdentifier`.
     public let storyboardIdentifier: String?
     
-    private enum CodingKeys: String, CodingKey {
-        case viewIdentifier, bundleIdentifier, storyboardIdentifier
-    }
+    /// The default bundle from the factory used to decode this object.
+    public var factoryBundle: Bundle? = nil
     
     /// Default initializer.
     ///
     /// - parameters:
-    ///     - viewIdentifier: The storyboard view controller identifier or the nib name for this view controller.
+    ///     - viewIdentifier: The storyboard view controller identifier or the nib name for this view
+    ///       controller.
     ///     - bundleIdentifier: The bundle identifier for the nib or storyboard. Default = `nil`.
     ///     - storyboardIdentifier: The storyboard identifier. Default = `nil`.
     public init(viewIdentifier: String, bundleIdentifier: String? = nil, storyboardIdentifier: String? = nil) {

--- a/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableTestObjects.swift
+++ b/ResearchSuite/ResearchSuiteTests/Codable Tests/CodableTestObjects.swift
@@ -42,9 +42,14 @@ class BundleWrapper {
 
 struct TestResourceWrapper : RSDResourceTransformer, Codable {
     
+    private enum CodingKeys : String, CodingKey {
+        case resourceName, bundleIdentifier, classType
+    }
+    
     let resourceName: String
     let bundleIdentifier: String?
     let classType: String?
+    var factoryBundle: Bundle? = nil
 
     public init(resourceName: String, bundleIdentifier: String?) {
         self.resourceName = resourceName


### PR DESCRIPTION
- Allow setting the resource bundle to the same bundle for all resources within the top-level decoded resource.
- Add a permissions error that has message info.