### PR TITLE
Refactor RSDConditionalStepNavigator and add unit tests

### DIFF
--- a/ResearchStack2/ResearchStack2/RSDConditionalStepNavigator.swift
+++ b/ResearchStack2/ResearchStack2/RSDConditionalStepNavigator.swift
@@ -184,16 +184,32 @@ extension RSDConditionalStepNavigator {
         return conditionalRule?.skipToStepIdentifier(before: returnStep, with: result, isPeeking: isPeeking)
     }
     
-    private func _nextStepIdentifier(after previousStep: RSDStep?, with result: RSDTaskResult, isPeeking: Bool) -> String? {
-        guard let navigableStep = previousStep as? RSDNavigationRule,
-            let nextStepIdentifier = navigableStep.nextStepIdentifier(with: result, conditionalRule: conditionalRule, isPeeking: isPeeking)
-            else {
-                // Check the conditional rule for a next step identifier
-                return _checkConditionalRules(after: previousStep, with: result, isPeeking: isPeeking)
+    private func _nextStepIdentifier(with parentResult: RSDTaskResult, isPeeking: Bool) -> String? {
+        guard let sectionStep = self as? RSDStep,
+              let taskResult = parentResult.findResult(for: sectionStep) as? RSDTaskResult,
+              let lastResult = taskResult.stepHistory.last,
+              let previousStep = self.step(with: lastResult.identifier)
+              else {
+                return nil
         }
-        // If this is a step that conforms to the RSDNavigationRule protocol and the next step is non-nil,
-        // then return this as the next step identifier
-        return nextStepIdentifier
+        return _nextStepIdentifier(after: previousStep, with: taskResult, isPeeking: isPeeking)
+    }
+    
+    private func _nextStepIdentifier(after previousStep: RSDStep?, with result: RSDTaskResult, isPeeking: Bool) -> String? {
+        if let sectionStep = previousStep as? RSDConditionalStepNavigator,
+           let nextStepIdentifer = sectionStep._nextStepIdentifier(with: result, isPeeking: isPeeking) {
+            return nextStepIdentifer
+        }
+        else if let navigableStep = previousStep as? RSDNavigationRule,
+                let nextStepIdentifier = navigableStep.nextStepIdentifier(with: result, conditionalRule: conditionalRule, isPeeking: isPeeking) {
+            // If this is a step that conforms to the RSDNavigationRule protocol and the next step is non-nil,
+            // then return this as the next step identifier
+            return nextStepIdentifier
+        }
+        else {
+            // Check the conditional rule for a next step identifier
+            return _checkConditionalRules(after: previousStep, with: result, isPeeking: isPeeking)
+        }
     }
     
     /// Should the task exit early from the entire task?

--- a/ResearchStack2/ResearchStack2/RSDConditionalStepNavigator.swift
+++ b/ResearchStack2/ResearchStack2/RSDConditionalStepNavigator.swift
@@ -196,6 +196,8 @@ extension RSDConditionalStepNavigator {
     }
     
     private func _nextStepIdentifier(after previousStep: RSDStep?, with result: RSDTaskResult, isPeeking: Bool) -> String? {
+        // If this is a step that conforms to RSDConditionalStepNavigator and the next step is non-nil,
+        // then return this as the next step identifier
         if let sectionStep = previousStep as? RSDConditionalStepNavigator,
            let nextStepIdentifer = sectionStep._nextStepIdentifier(with: result, isPeeking: isPeeking) {
             return nextStepIdentifer

--- a/ResearchStack2/ResearchStack2Tests/Navigation Tests/NavigationTestObjects.swift
+++ b/ResearchStack2/ResearchStack2Tests/Navigation Tests/NavigationTestObjects.swift
@@ -34,12 +34,17 @@
 import Foundation
 import ResearchStack2
 
-struct TestStep : RSDStep {
+struct TestStep : RSDStep, RSDNavigationRule {
+    
+    func nextStepIdentifier(with result: RSDTaskResult?, conditionalRule: RSDConditionalRule?, isPeeking: Bool) -> String? {
+        return self.nextStepIdentifier
+    }
     
     let identifier: String
     var stepType: RSDStepType = .instruction
     var result: RSDResult?
     var validationError: Error?
+    var nextStepIdentifier: String?
     
     init(identifier: String) {
         self.identifier = identifier

--- a/ResearchStack2/ResearchStack2Tests/Navigation Tests/NavigationTestObjects.swift
+++ b/ResearchStack2/ResearchStack2Tests/Navigation Tests/NavigationTestObjects.swift
@@ -36,15 +36,15 @@ import ResearchStack2
 
 struct TestStep : RSDStep, RSDNavigationRule {
     
-    func nextStepIdentifier(with result: RSDTaskResult?, conditionalRule: RSDConditionalRule?, isPeeking: Bool) -> String? {
-        return self.nextStepIdentifier
-    }
-    
     let identifier: String
     var stepType: RSDStepType = .instruction
     var result: RSDResult?
     var validationError: Error?
     var nextStepIdentifier: String?
+    
+    func nextStepIdentifier(with result: RSDTaskResult?, conditionalRule: RSDConditionalRule?, isPeeking: Bool) -> String? {
+        return self.nextStepIdentifier
+    }
     
     init(identifier: String) {
         self.identifier = identifier

--- a/ResearchStack2/ResearchStack2Tests/Navigation Tests/TaskControllerTests.swift
+++ b/ResearchStack2/ResearchStack2Tests/Navigation Tests/TaskControllerTests.swift
@@ -276,4 +276,73 @@ class TaskControllerTests: XCTestCase {
         
         XCTAssertEqual(taskController.taskPath.stepPath, "introduction, step1, step2, step3")
     }
+    
+    
+    func testJumpBackward() {
+        var steps: [RSDStep] = []
+        let beforeSteps: [RSDStep] = TestStep.steps(from: ["introduction", "step1", "step2", "step3"])
+        steps.append(contentsOf: beforeSteps)
+        
+        var sectionSteps = TestStep.steps(from: ["stepA", "stepB", "stepC"])
+        var stepB = sectionSteps[1]
+        stepB.nextStepIdentifier = "stepA"
+        sectionSteps.remove(at: 1)
+        sectionSteps.insert(stepB, at: 1)
+        
+        steps.append(RSDSectionStepObject(identifier: "step4", steps: sectionSteps))
+        steps.append(RSDSectionStepObject(identifier: "step5", steps: TestStep.steps(from: ["stepX", "stepY", "stepZ"])))
+        steps.append(RSDSectionStepObject(identifier: "step6", steps: TestStep.steps(from: ["stepA", "stepB", "stepC"])))
+        let afterSteps: [RSDStep] = TestStep.steps(from: ["step7", "completion"])
+        steps.append(contentsOf: afterSteps)
+        
+        var navigator = TestConditionalNavigator(steps: steps)
+        navigator.progressMarkers = ["step1", "step2", "step3", "step4", "step5", "step6", "step7"]
+        
+        let task = TestTask(identifier: "test", stepNavigator: navigator)
+        
+        let taskController = TestTaskController()
+        taskController.topLevelTask = task
+        
+        // set up for the step controller
+        let _ = taskController.test_stepTo("stepB")
+        taskController.goForward()
+        
+        let stepTo = taskController.navigate_calledTo
+        XCTAssertNotNil(stepTo)
+        XCTAssertEqual(stepTo?.identifier, "stepA")
+    }
+    
+    func testJumpBackward_OutOfSection() {
+        var steps: [RSDStep] = []
+        let beforeSteps: [RSDStep] = TestStep.steps(from: ["introduction", "step1", "step2", "step3"])
+        steps.append(contentsOf: beforeSteps)
+        
+        var sectionSteps = TestStep.steps(from: ["stepA", "stepB", "stepC"])
+        var stepB = sectionSteps[1]
+        stepB.nextStepIdentifier = "step1"
+        sectionSteps.remove(at: 1)
+        sectionSteps.insert(stepB, at: 1)
+        
+        steps.append(RSDSectionStepObject(identifier: "step4", steps: sectionSteps))
+        steps.append(RSDSectionStepObject(identifier: "step5", steps: TestStep.steps(from: ["stepX", "stepY", "stepZ"])))
+        steps.append(RSDSectionStepObject(identifier: "step6", steps: TestStep.steps(from: ["stepA", "stepB", "stepC"])))
+        let afterSteps: [RSDStep] = TestStep.steps(from: ["step7", "completion"])
+        steps.append(contentsOf: afterSteps)
+        
+        var navigator = TestConditionalNavigator(steps: steps)
+        navigator.progressMarkers = ["step1", "step2", "step3", "step4", "step5", "step6", "step7"]
+        
+        let task = TestTask(identifier: "test", stepNavigator: navigator)
+        
+        let taskController = TestTaskController()
+        taskController.topLevelTask = task
+        
+        // set up for the step controller
+        let _ = taskController.test_stepTo("stepB")
+        taskController.goForward()
+        
+        let stepTo = taskController.navigate_calledTo
+        XCTAssertNotNil(stepTo)
+        XCTAssertEqual(stepTo?.identifier, "step1")
+    }
 }


### PR DESCRIPTION
Previously RSDConditionalStepNavigator did not support navigating from a step inside a section step, to a step outside the section step. Fixed this issue, as well as added unit tests that test to ensure this feature is working.