### PR TITLE
Allow the motion recorder to delete the file from a previous run on restart.

### DIFF
--- a/ResearchStack2/ResearchStack2/RSDAsyncActionConfiguration.swift
+++ b/ResearchStack2/ResearchStack2/RSDAsyncActionConfiguration.swift
@@ -102,6 +102,13 @@ public protocol RSDRecorderConfiguration : RSDAsyncActionConfiguration {
     var requiresBackgroundAudio: Bool { get }
 }
 
+/// Extends `RSDRecorderConfiguration` for a recorder that might be restarted.
+public protocol RSDRestartableRecorderConfiguration : RSDRecorderConfiguration {
+    
+    /// Should the file used in a previous run of a recording be deleted?
+    var shouldDeletePrevious: Bool { get }
+}
+
 /// `RSDJSONRecorderConfigureation` is used to configure a recorder to record JSON samples.
 /// - seealso: `RSDSampleRecorder`
 public protocol RSDJSONRecorderConfiguration : RSDRecorderConfiguration {

--- a/ResearchStack2/ResearchStack2/RSDDataLogger.swift
+++ b/ResearchStack2/ResearchStack2/RSDDataLogger.swift
@@ -135,7 +135,7 @@ public class RSDFileResultUtility {
     ///     - outputDirectory: File URL for the directory in which to store generated data files.
     /// - returns: Scrubbed URL for the given identifier.
     /// - throws: An exception if the file directory cannot be created.
-    public static func createFileURL(identifier: String, ext: String, outputDirectory: URL) throws -> URL {
+    public static func createFileURL(identifier: String, ext: String, outputDirectory: URL, shouldDeletePrevious: Bool = false) throws -> URL {
 
         // create the directory if needed
         try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true, attributes: nil)
@@ -153,11 +153,20 @@ public class RSDFileResultUtility {
         let url = URL(fileURLWithPath: relativePath, relativeTo: outputDirectory)
         if !FileManager.default.fileExists(atPath: url.path) {
             return url
-        } else {
-            assertionFailure("A file already exists at \(filename).")
-            let uuidCode = UUID().uuidString.prefix(4)
-            return URL(fileURLWithPath: "\(filename)-\(uuidCode).\(ext)", relativeTo: outputDirectory)
         }
+        else if shouldDeletePrevious, FileManager.default.isDeletableFile(atPath: url.path) {
+            do {
+                try FileManager.default.removeItem(at: url)
+                return url
+            }
+            catch let err {
+                debugPrint("Failed to delete file. \(err)")
+            }
+        }
+        
+        assertionFailure("A file already exists at \(filename).")
+        let uuidCode = UUID().uuidString.prefix(4)
+        return URL(fileURLWithPath: "\(filename)-\(uuidCode).\(ext)", relativeTo: outputDirectory)
     }
     
     /// Convenience method for creating a file URL for a given reserved file name to use as the location

--- a/ResearchStack2/ResearchStack2/RSDSampleRecorder.swift
+++ b/ResearchStack2/ResearchStack2/RSDSampleRecorder.swift
@@ -577,7 +577,8 @@ open class RSDSampleRecorder : NSObject, RSDAsyncActionController {
     open func instantiateLogger(with identifier: String) throws -> RSDDataLogger? {
         let format = stringEncodingFormat()
         let ext = format?.fileExtension ?? "json"
-        let url = try RSDFileResultUtility.createFileURL(identifier: identifier, ext: ext, outputDirectory: outputDirectory)
+        let shouldDelete = (self.configuration as? RSDRestartableRecorderConfiguration)?.shouldDeletePrevious ?? false
+        let url = try RSDFileResultUtility.createFileURL(identifier: identifier, ext: ext, outputDirectory: outputDirectory, shouldDeletePrevious: shouldDelete)
         return try RSDRecordSampleLogger(identifier: identifier, url: url, usesRootDictionary: self.usesRootDictionary, stringEncodingFormat: format)
     }
     


### PR DESCRIPTION
The recorders previously used are designed to throw an assert if you attempt to store a recording to the same filename as a previous recording (within the same task run). This fails for the case where the steps use a looping navigation to restart the step because the recorder tries to record to the same filename and throws an assert. This allows a recorder to restart the step and simply delete the previous recording upon the assumption that this previous run is not required.