### PR TITLE
Refactor the step view controller for tapping view controller.

### DIFF
--- a/ResearchStack2/ResearchStack2/RSDStepController.swift
+++ b/ResearchStack2/ResearchStack2/RSDStepController.swift
@@ -90,6 +90,17 @@ extension RSDStepController {
         return self.taskController as? RSDTaskUIController
     }
     
+    /// Convenience var for accessing the step path.
+    public var stepPath: String {
+        return self.taskController?.taskPath.stepPath ?? ""
+    }
+    
+    /// Convenience method for accessing the step result associated with this step.
+    public func findStepResult() -> RSDResult? {
+        guard let step = self.step, let taskPath = self.taskController?.taskPath else { return nil }
+        return taskPath.result.findResult(for: step)
+    }
+    
     /// Conveniece method for getting the progress through the task for the current step with
     /// the current result.
     ///


### PR DESCRIPTION
This allows for the active steps to speak the "end" instruction without automatically going forward. Also, once the end instruction has been spoken, do not speak it again.