### PR TITLE
Refactor section transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
 .DS_Store
+/ResearchStack2.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist

--- a/ResearchStack2/ResearchStack2.xcodeproj/project.pbxproj
+++ b/ResearchStack2/ResearchStack2.xcodeproj/project.pbxproj
@@ -406,19 +406,19 @@
 		FF8B54251FCE6CA2006B6937 /* RSDGenericStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD243271F9561500083F458 /* RSDGenericStepObject.swift */; };
 		FF8B54261FCE6CA2006B6937 /* RSDSectionStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8E5F3E1F8C258200611C23 /* RSDSectionStepObject.swift */; };
 		FF8B54271FCE6CA2006B6937 /* RSDUIStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF74A7DB1F7DA2BF0064A634 /* RSDUIStepObject.swift */; };
-		FF8B54281FCE6CA2006B6937 /* RSDTransformerStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBD07371FAA46CD000CB34F /* RSDTransformerStepObject.swift */; };
+		FF8B54281FCE6CA2006B6937 /* RSDStepTransformerObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBD07371FAA46CD000CB34F /* RSDStepTransformerObject.swift */; };
 		FF8B54291FCE6CA2006B6937 /* RSDActiveUIStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF580BF31F7E3764009B3EE9 /* RSDActiveUIStepObject.swift */; };
 		FF8B542A1FCE6CA2006B6937 /* RSDFormUIStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE0DE4E1F874A8600BB1BDF /* RSDFormUIStepObject.swift */; };
 		FF8B542B1FCE6CA2006B6937 /* RSDGenericStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD243271F9561500083F458 /* RSDGenericStepObject.swift */; };
 		FF8B542C1FCE6CA2006B6937 /* RSDSectionStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8E5F3E1F8C258200611C23 /* RSDSectionStepObject.swift */; };
 		FF8B542D1FCE6CA2006B6937 /* RSDUIStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF74A7DB1F7DA2BF0064A634 /* RSDUIStepObject.swift */; };
-		FF8B542E1FCE6CA2006B6937 /* RSDTransformerStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBD07371FAA46CD000CB34F /* RSDTransformerStepObject.swift */; };
+		FF8B542E1FCE6CA2006B6937 /* RSDStepTransformerObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBD07371FAA46CD000CB34F /* RSDStepTransformerObject.swift */; };
 		FF8B542F1FCE6CA3006B6937 /* RSDActiveUIStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF580BF31F7E3764009B3EE9 /* RSDActiveUIStepObject.swift */; };
 		FF8B54301FCE6CA3006B6937 /* RSDFormUIStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE0DE4E1F874A8600BB1BDF /* RSDFormUIStepObject.swift */; };
 		FF8B54311FCE6CA3006B6937 /* RSDGenericStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD243271F9561500083F458 /* RSDGenericStepObject.swift */; };
 		FF8B54321FCE6CA3006B6937 /* RSDSectionStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8E5F3E1F8C258200611C23 /* RSDSectionStepObject.swift */; };
 		FF8B54331FCE6CA3006B6937 /* RSDUIStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF74A7DB1F7DA2BF0064A634 /* RSDUIStepObject.swift */; };
-		FF8B54341FCE6CA3006B6937 /* RSDTransformerStepObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBD07371FAA46CD000CB34F /* RSDTransformerStepObject.swift */; };
+		FF8B54341FCE6CA3006B6937 /* RSDStepTransformerObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBD07371FAA46CD000CB34F /* RSDStepTransformerObject.swift */; };
 		FF8B543B1FCE6CA9006B6937 /* RSDChoiceObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBA00031F85657C0079A404 /* RSDChoiceObject.swift */; };
 		FF8B543C1FCE6CA9006B6937 /* RSDChoiceInputFieldObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6A4AC1F859B0100E37752 /* RSDChoiceInputFieldObject.swift */; };
 		FF8B543D1FCE6CA9006B6937 /* RSDComparableSurveyRuleObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF63E83C1FBAE5C80060DD98 /* RSDComparableSurveyRuleObject.swift */; };
@@ -745,7 +745,7 @@
 		FFB6A4B81F8607C300E37752 /* RSDDurationRangeObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDDurationRangeObject.swift; sourceTree = "<group>"; };
 		FFBA00031F85657C0079A404 /* RSDChoiceObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDChoiceObject.swift; sourceTree = "<group>"; };
 		FFBD07351FAA3E4B000CB34F /* RSDSectionStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDSectionStep.swift; sourceTree = "<group>"; };
-		FFBD07371FAA46CD000CB34F /* RSDTransformerStepObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDTransformerStepObject.swift; sourceTree = "<group>"; };
+		FFBD07371FAA46CD000CB34F /* RSDStepTransformerObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDStepTransformerObject.swift; sourceTree = "<group>"; };
 		FFBD07391FAA53DD000CB34F /* RSDThemedUIStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDThemedUIStep.swift; sourceTree = "<group>"; };
 		FFBD073C1FAA5B96000CB34F /* RSDColorThemeElementObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDColorThemeElementObject.swift; sourceTree = "<group>"; };
 		FFBD073E1FAA603E000CB34F /* RSDImageThemeObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSDImageThemeObject.swift; sourceTree = "<group>"; };
@@ -1198,7 +1198,7 @@
 				F8E94FDF2058308B00752B7B /* RSDOverviewStepObject.swift */,
 				FF8E5F3E1F8C258200611C23 /* RSDSectionStepObject.swift */,
 				FF74A7DB1F7DA2BF0064A634 /* RSDUIStepObject.swift */,
-				FFBD07371FAA46CD000CB34F /* RSDTransformerStepObject.swift */,
+				FFBD07371FAA46CD000CB34F /* RSDStepTransformerObject.swift */,
 			);
 			name = Step;
 			sourceTree = "<group>";
@@ -1787,7 +1787,7 @@
 				FF8B53A41FCE6C7A006B6937 /* RSDDateCoder.swift in Sources */,
 				F8C28F28204F09CE00863F5F /* RSDDataArchiveManager.swift in Sources */,
 				FF8B54BF1FCE6D09006B6937 /* RSDJSONValue.swift in Sources */,
-				FF8B54281FCE6CA2006B6937 /* RSDTransformerStepObject.swift in Sources */,
+				FF8B54281FCE6CA2006B6937 /* RSDStepTransformerObject.swift in Sources */,
 				F829F0DB1FF86DA4001B0680 /* RSDMassFormatter.m in Sources */,
 				FF8B543E1FCE6CA9006B6937 /* RSDInputFieldObject.swift in Sources */,
 			);
@@ -1975,7 +1975,7 @@
 				FF8B53B91FCE6C7B006B6937 /* RSDDateCoder.swift in Sources */,
 				FF633D9D1FCE857900CF2267 /* RSDDocumentable.swift in Sources */,
 				FF8B54C51FCE6D0A006B6937 /* RSDJSONValue.swift in Sources */,
-				FF8B542E1FCE6CA2006B6937 /* RSDTransformerStepObject.swift in Sources */,
+				FF8B542E1FCE6CA2006B6937 /* RSDStepTransformerObject.swift in Sources */,
 				F829F0DC1FF86DA4001B0680 /* RSDMassFormatter.m in Sources */,
 				FF8B54451FCE6CAA006B6937 /* RSDInputFieldObject.swift in Sources */,
 			);
@@ -2127,7 +2127,7 @@
 				FF8B53FE1FCE6C87006B6937 /* RSDDateCoderObject.swift in Sources */,
 				FF8B53CE1FCE6C7B006B6937 /* RSDDateCoder.swift in Sources */,
 				FF8B54CB1FCE6D0B006B6937 /* RSDJSONValue.swift in Sources */,
-				FF8B54341FCE6CA3006B6937 /* RSDTransformerStepObject.swift in Sources */,
+				FF8B54341FCE6CA3006B6937 /* RSDStepTransformerObject.swift in Sources */,
 				FF8B544C1FCE6CAA006B6937 /* RSDInputFieldObject.swift in Sources */,
 				F80CA51D1FFEAD1F00E89C06 /* RSDUSMeasurementPickerDataSource.swift in Sources */,
 			);

--- a/ResearchStack2/ResearchStack2/RSDActiveUIStepObject.swift
+++ b/ResearchStack2/ResearchStack2/RSDActiveUIStepObject.swift
@@ -157,13 +157,13 @@ open class RSDActiveUIStepObject : RSDUIStepObject, RSDActiveUIStep {
     }
     
     /// Override to set the properties of the subclass.
-    override open func copyInto(_ copy: RSDUIStepObject, userInfo: [String : Any]?) throws {
-        try super.copyInto(copy, userInfo: userInfo)
+    override open func copyInto(_ copy: RSDUIStepObject) {
+        super.copyInto(copy)
         guard let subclassCopy = copy as? RSDActiveUIStepObject else {
             assertionFailure("Superclass implementation of the `copy(with:)` protocol should return an instance of this class.")
             return
         }
-        subclassCopy.duration = userInfo?[CodingKeys.duration.stringValue] as? TimeInterval ?? self.duration
+        subclassCopy.duration = self.duration
         subclassCopy.commands = self.commands
         subclassCopy.requiresBackgroundAudio = self.requiresBackgroundAudio
         subclassCopy.spokenInstructions = self.spokenInstructions

--- a/ResearchStack2/ResearchStack2/RSDDocumentable.swift
+++ b/ResearchStack2/ResearchStack2/RSDDocumentable.swift
@@ -167,7 +167,7 @@ public struct RSDDocumentCreator {
         RSDSectionStepObject.self,
         RSDTrackedItemsReviewStepObject.self,
         RSDTrackedSelectionStepObject.self,
-        RSDTransformerStepObject.self,
+        RSDStepTransformerObject.self,
         RSDInputFieldObject.self,
         RSDChoiceInputFieldObject.self,
         RSDSchemaInfoObject.self,

--- a/ResearchStack2/ResearchStack2/RSDFactory.swift
+++ b/ResearchStack2/ResearchStack2/RSDFactory.swift
@@ -286,7 +286,7 @@ open class RSDFactory {
         }
     }
     
-    /// Decode the step into a transfrom step. By default, this will create a `RSDTransformerStepObject`.
+    /// Decode the step into a transfrom step. By default, this will create a `RSDStepTransformerObject`.
     ///
     /// - parameter decoder: The decoder to use to instatiate the object.
     /// - returns: The step transform created from this decoder.

--- a/ResearchStack2/ResearchStack2/RSDFormUIStepObject.swift
+++ b/ResearchStack2/ResearchStack2/RSDFormUIStepObject.swift
@@ -52,8 +52,8 @@ open class RSDFormUIStepObject : RSDUIStepObject, RSDFormUIStep, RSDSurveyNaviga
     }
     
     /// Override to set the properties of the subclass.
-    override open func copyInto(_ copy: RSDUIStepObject, userInfo: [String : Any]?) throws {
-        try super.copyInto(copy, userInfo: userInfo)
+    override open func copyInto(_ copy: RSDUIStepObject) {
+        super.copyInto(copy)
         guard let subclassCopy = copy as? RSDFormUIStepObject else {
             assertionFailure("Superclass implementation of the `copy(with:)` protocol should return an instance of this class.")
             return

--- a/ResearchStack2/ResearchStack2/RSDOverviewStepObject.swift
+++ b/ResearchStack2/ResearchStack2/RSDOverviewStepObject.swift
@@ -59,8 +59,8 @@ open class RSDOverviewStepObject : RSDUIStepObject, RSDStandardPermissionsStep {
     }
     
     /// Override to set the properties of the subclass.
-    override open func copyInto(_ copy: RSDUIStepObject, userInfo: [String : Any]?) throws {
-        try super.copyInto(copy, userInfo: userInfo)
+    override open func copyInto(_ copy: RSDUIStepObject) {
+        super.copyInto(copy)
         guard let subclassCopy = copy as? RSDOverviewStepObject else {
             assertionFailure("Superclass implementation of the `copy(with:)` protocol should return an instance of this class.")
             return

--- a/ResearchStack2/ResearchStack2/RSDPopoverInputFieldObject.swift
+++ b/ResearchStack2/ResearchStack2/RSDPopoverInputFieldObject.swift
@@ -126,14 +126,14 @@ open class RSDPopoverInputFieldObject : RSDFormUIStepObject, RSDPopoverInputFiel
         case prompt, promptDetail, placeholder
     }
     
-    open override func copyInto(_ copy: RSDUIStepObject, userInfo: [String : Any]?) throws {
-        try super.copyInto(copy, userInfo: userInfo)
+    open override func copyInto(_ copy: RSDUIStepObject) {
+        super.copyInto(copy)
         guard let subclassCopy = copy as? RSDPopoverInputFieldObject else {
             assertionFailure("Superclass implementation of the `copy(with:)` protocol should return an instance of this class.")
             return
         }
-        subclassCopy.inputPrompt = userInfo?[CodingKeys.prompt.stringValue] as? String ?? self.inputPrompt
-        subclassCopy.inputPromptDetail = userInfo?[CodingKeys.promptDetail.stringValue] as? String ?? self.inputPromptDetail
-        subclassCopy.placeholder = userInfo?[CodingKeys.placeholder.stringValue] as? String ?? self.placeholder
+        subclassCopy.inputPrompt = self.inputPrompt
+        subclassCopy.inputPromptDetail = self.inputPromptDetail
+        subclassCopy.placeholder = self.placeholder
     }
 }

--- a/ResearchStack2/ResearchStack2/RSDResourceTransformer.swift
+++ b/ResearchStack2/ResearchStack2/RSDResourceTransformer.swift
@@ -84,7 +84,7 @@ extension RSDResourceConfig {
 
 /// `RSDResourceTransformer` is a protocol for getting either embedded resources or online resources.
 ///
-/// - seealso: `RSDSectionStepResourceTransformer` and `RSDTaskResourceTransformer`
+/// - seealso: `RSDStepResourceTransformer` and `RSDTaskResourceTransformer`
 ///
 public protocol RSDResourceTransformer: RSDDecodableBundleInfo {
     

--- a/ResearchStack2/ResearchStack2/RSDResourceTransformerObject.swift
+++ b/ResearchStack2/ResearchStack2/RSDResourceTransformerObject.swift
@@ -84,9 +84,6 @@ public final class RSDResourceTransformerObject : Codable {
 extension RSDResourceTransformerObject : RSDTaskResourceTransformer {
 }
 
-extension RSDResourceTransformerObject : RSDSectionStepResourceTransformer {
-}
-
 extension RSDResourceTransformerObject : RSDDocumentableCodableObject {
     
     static func codingKeys() -> [CodingKey] {

--- a/ResearchStack2/ResearchStack2/RSDStep.swift
+++ b/ResearchStack2/ResearchStack2/RSDStep.swift
@@ -92,8 +92,8 @@ public protocol RSDCopyStep : RSDStep, RSDCopyWithIdentifier {
     /// Copy the step to a new instance with the given identifier and user info.
     /// - parameters:
     ///     - identifier: The new identifier.
-    ///     - userInfo: A dictionary that can be used to set properties on a replacement step.
-    func copy(with identifier: String, userInfo: [String : Any]?) throws -> Self
+    ///     - decoder: A decoder that can be used to decode properties on this step.
+    func copy(with identifier: String, decoder: Decoder?) throws -> Self
 }
 
 /// `RSDGenericStep` is a step with key/value pairs decoded from a dictionary. This is the default step

--- a/ResearchStack2/ResearchStack2/RSDStepTransformerObject.swift
+++ b/ResearchStack2/ResearchStack2/RSDStepTransformerObject.swift
@@ -1,5 +1,5 @@
 //
-//  RSDTransformerStepObject.swift
+//  RSDStepTransformerObject.swift
 //  ResearchStack2
 //
 //  Copyright © 2017 Sage Bionetworks. All rights reserved.
@@ -33,7 +33,7 @@
 
 import Foundation
 
-/// `RSDTransformerStepObject` is used in decoding a step with replacement properties for some or all of the steps in a
+/// `RSDStepTransformerObject` is used in decoding a step with replacement properties for some or all of the steps in a
 /// section that is defined using a different resource. The factory will convert this step into an appropriate
 /// `RSDSectionStep` from the decoded object.
 public struct RSDStepTransformerObject : RSDStepTransformer, Decodable {

--- a/ResearchStack2/ResearchStack2/RSDTrackedItemDetailsStepObject.swift
+++ b/ResearchStack2/ResearchStack2/RSDTrackedItemDetailsStepObject.swift
@@ -87,8 +87,8 @@ open class RSDTrackedItemDetailsStepObject : RSDFormUIStepObject, RSDTrackedItem
     }
     
     /// Override copy into to copy the schedule templates.
-    open override func copyInto(_ copy: RSDUIStepObject, userInfo: [String : Any]?) throws {
-        try super.copyInto(copy, userInfo: userInfo)
+    open override func copyInto(_ copy: RSDUIStepObject) {
+        super.copyInto(copy)
         guard let subclassCopy = copy as? RSDTrackedItemDetailsStepObject else {
             assertionFailure("Superclass implementation of the `copy(with:)` protocol should return an instance of this class.")
             return

--- a/ResearchStack2/ResearchStack2/RSDTrackedItemsReviewStepObject.swift
+++ b/ResearchStack2/ResearchStack2/RSDTrackedItemsReviewStepObject.swift
@@ -98,16 +98,16 @@ open class RSDTrackedItemsReviewStepObject : RSDTrackedSelectionStepObject {
     }
     
     /// Override to set the properties of the subclass.
-    override open func copyInto(_ copy: RSDUIStepObject, userInfo: [String : Any]?) throws {
-        try super.copyInto(copy, userInfo: userInfo)
+    override open func copyInto(_ copy: RSDUIStepObject) {
+        super.copyInto(copy)
         guard let subclassCopy = copy as? RSDTrackedItemsReviewStepObject else {
             assertionFailure("Superclass implementation of the `copy(with:)` protocol should return an instance of this class.")
             return
         }
-        subclassCopy.addDetailsTitle = userInfo?[CodingKeys.addDetailsTitle.stringValue] as? String ?? self.addDetailsTitle
-        subclassCopy.addDetailsSubtitle = userInfo?[CodingKeys.addDetailsSubtitle.stringValue] as? String ?? self.addDetailsSubtitle
-        subclassCopy.reviewTitle = userInfo?[CodingKeys.reviewTitle.stringValue] as? String ?? self.reviewTitle
-        subclassCopy.reviewSubtitle = userInfo?[CodingKeys.reviewSubtitle.stringValue] as? String ?? self.reviewSubtitle
+        subclassCopy.addDetailsTitle = self.addDetailsTitle
+        subclassCopy.addDetailsSubtitle = self.addDetailsSubtitle
+        subclassCopy.reviewTitle = self.reviewTitle
+        subclassCopy.reviewSubtitle = self.reviewSubtitle
     }
     
     // Overrides must be defined in the base implementation

--- a/ResearchStack2/ResearchStack2/RSDTrackedSelectionStepObject.swift
+++ b/ResearchStack2/ResearchStack2/RSDTrackedSelectionStepObject.swift
@@ -60,8 +60,8 @@ open class RSDTrackedSelectionStepObject : RSDUIStepObject, RSDTrackedItemsStep 
     }
     
     /// Override to set the properties of the subclass.
-    override open func copyInto(_ copy: RSDUIStepObject, userInfo: [String : Any]?) throws {
-        try super.copyInto(copy, userInfo: userInfo)
+    override open func copyInto(_ copy: RSDUIStepObject) {
+        super.copyInto(copy)
         guard let subclassCopy = copy as? RSDTrackedSelectionStepObject else {
             assertionFailure("Superclass implementation of the `copy(with:)` protocol should return an instance of this class.")
             return

--- a/ResearchStack2/ResearchStack2/RSDUIStepObject.swift
+++ b/ResearchStack2/ResearchStack2/RSDUIStepObject.swift
@@ -119,31 +119,30 @@ open class RSDUIStepObject : RSDUIActionHandlerObject, RSDThemedUIStep, RSDTable
     /// Copy the step to a new instance with the given identifier, but otherwise, equal.
     /// - parameter identifier: The new identifier.
     public func copy(with identifier: String) -> Self {
-        return try! copy(with: identifier, userInfo: nil)
+        return try! copy(with: identifier, decoder: nil)
     }
     
     /// Copy the step to a new instance with the given identifier and user info.
     /// - parameters:
     ///     - identifier: The new identifier.
-    ///     - userInfo: A dictionary that can be used to set properties on a replacement step.
-    public func copy(with identifier: String, userInfo: [String : Any]?) throws -> Self {
+    ///     - decoder: A decoder that can be used to decode properties on this step.
+    public func copy(with identifier: String, decoder: Decoder?) throws -> Self {
         let copy = type(of: self).init(identifier: identifier, type: self.stepType)
-        try copyInto(copy as RSDUIStepObject, userInfo: userInfo)
+        self.copyInto(copy)
+        if let decoder = decoder {
+            try copy.decode(from: decoder, for: nil)
+        }
         return copy
     }
     
     /// Swift subclass override for copying properties from the instantiated class of the `copy(with:)`
     /// method. Swift does not nicely handle casting from `Self` to a class instance for non-final classes.
     /// This is a work-around.
-    open func copyInto(_ copy: RSDUIStepObject, userInfo: [String : Any]?) throws {
-        
-        copy.title = userInfo?[CodingKeys.title.stringValue] as? String ?? self.title
-        copy.text = userInfo?[CodingKeys.text.stringValue] as? String ?? self.text
-        copy.detail = userInfo?[CodingKeys.detail.stringValue] as? String ?? self.detail
-        copy.footnote = userInfo?[CodingKeys.footnote.stringValue] as? String ?? self.footnote
-
-        // TODO: syoung 02/26/2018 Use `Decodable` to support copying from dictionaries.
-        // https://github.com/ResearchKit/SageResearch/issues/42
+    open func copyInto(_ copy: RSDUIStepObject) {
+        copy.title = self.title
+        copy.text = self.text
+        copy.detail = self.detail
+        copy.footnote = self.footnote
         copy.viewTheme = self.viewTheme
         copy.colorTheme = self.colorTheme
         copy.imageTheme = self.imageTheme


### PR DESCRIPTION
Simplify the implementation for transforming a section step that uses an embedded resource from a different code file. The protocols in the factory are now intentionally vague with a simplified implementation that assumes the resource is in the same resource bundle as the transformer.

This will allow progress markers and async actions to be defined in a resource file for a section step with only the steps including decodable replacement properties. Also, this assumes that the properties are decoded from a JSON file rather than a dictionary, so the transformer can include theme objects.