### PR TITLE
Remove build mailing list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-notifications:
-  email:
-  - apple.builds@sagebase.org
 language: objective-c
 osx_image: xcode9.3
 xcode_workspace: Research.xcworkspace


### PR DESCRIPTION
Setting notification to mailing list only sends to the ML.
Removing it will allow travis to send build failure
notifications to specific users.